### PR TITLE
feat(experimental): add curry to functional lib

### DIFF
--- a/packages/functional/src/__tests__/curry-test.ts
+++ b/packages/functional/src/__tests__/curry-test.ts
@@ -1,0 +1,212 @@
+import { curry } from '../curry';
+
+describe('curry', () => {
+    describe('basic functions with 1 argument', () => {
+        const upper = (a: string) => a.toUpperCase();
+        it('can curry a function without binding any arguments', () => {
+            const curriedUpper = curry(upper);
+            expect(curriedUpper('hello')).toBe('HELLO');
+        });
+        it('can curry a function and bind all arguments', () => {
+            const curriedUpper = curry(upper, 'hello');
+            expect(curriedUpper()).toBe('HELLO');
+        });
+        it('can call the curried function multiple times', () => {
+            const curriedUpper = curry(upper);
+            expect(curriedUpper('hello')).toBe('HELLO');
+            expect(curriedUpper('world')).toBe('WORLD');
+            expect(curriedUpper('again')).toBe('AGAIN');
+        });
+    });
+    describe('basic functions with 2 arguments', () => {
+        const concat = (a: string, b: string) => a + b;
+        it('can curry a function without binding any arguments', () => {
+            const curriedConcat = curry(concat);
+            expect(curriedConcat('hello', 'world')).toBe('helloworld');
+        });
+        it('can curry a function and bind 1 argument', () => {
+            const curriedConcat = curry(concat, 'hello');
+            expect(curriedConcat('world')).toBe('helloworld');
+        });
+        it('can curry a function and bind all arguments', () => {
+            const curriedConcat = curry(concat, 'hello', 'world');
+            expect(curriedConcat()).toBe('helloworld');
+        });
+        it('can call the curried function multiple times', () => {
+            const curriedConcat = curry(concat);
+            expect(curriedConcat('hello', 'world')).toBe('helloworld');
+            expect(curriedConcat('again', ' and again')).toBe('again and again');
+            expect(curriedConcat('over', ' and over')).toBe('over and over');
+        });
+    });
+    describe('basic functions with 5 arguments', () => {
+        const concat = (a: string, b: string, c: string, d: string, e: string) => a + b + c + d + e;
+        it('can curry a function without binding any arguments', () => {
+            const curriedConcat = curry(concat);
+            expect(curriedConcat('h', 'e', 'l', 'l', 'o')).toBe('hello');
+        });
+        it('can curry a function and bind 1 argument', () => {
+            const curriedConcat = curry(concat, 'h');
+            expect(curriedConcat('e', 'l', 'l', 'o')).toBe('hello');
+        });
+        it('can curry a function and bind 2 arguments', () => {
+            const curriedConcat = curry(concat, 'h', 'e');
+            expect(curriedConcat('l', 'l', 'o')).toBe('hello');
+        });
+        it('can curry a function and bind 3 arguments', () => {
+            const curriedConcat = curry(concat, 'h', 'e', 'l');
+            expect(curriedConcat('l', 'o')).toBe('hello');
+        });
+        it('can curry a function and bind 4 arguments', () => {
+            const curriedConcat = curry(concat, 'h', 'e', 'l', 'l');
+            expect(curriedConcat('o')).toBe('hello');
+        });
+        it('can curry a function and bind all arguments', () => {
+            const curriedConcat = curry(concat, 'h', 'e', 'l', 'l', 'o');
+            expect(curriedConcat()).toBe('hello');
+        });
+    });
+    describe('mutating objects', () => {
+        const mutate = (obj: { a: number; b: number }) => {
+            obj.a = 1;
+            obj.b = 2;
+            return obj;
+        };
+        it('can curry a function without binding any arguments', () => {
+            const curriedMutate = curry(mutate);
+            const obj = { a: 0, b: 0 };
+            expect(curriedMutate(obj)).toEqual({ a: 1, b: 2 });
+        });
+        it('can curry a function and bind 1 argument', () => {
+            const curriedMutate = curry(mutate, { a: 0, b: 0 });
+            expect(curriedMutate()).toEqual({ a: 1, b: 2 });
+        });
+    });
+    describe('combining objects', () => {
+        const combine = (a: { a: number }, b: { b: number }) => ({ ...a, ...b });
+        it('can curry a function without binding any arguments', () => {
+            const curriedCombine = curry(combine);
+            expect(curriedCombine({ a: 1 }, { b: 2 })).toEqual({ a: 1, b: 2 });
+        });
+        it('can curry a function and bind 1 argument', () => {
+            const curriedCombine = curry(combine, { a: 1 });
+            expect(curriedCombine({ b: 2 })).toEqual({ a: 1, b: 2 });
+        });
+        it('can curry a function and bind all arguments', () => {
+            const curriedCombine = curry(combine, { a: 1 }, { b: 2 });
+            expect(curriedCombine()).toEqual({ a: 1, b: 2 });
+        });
+    });
+    describe('combining arrays', () => {
+        const combine = (a: number[], b: number[]) => [...a, ...b];
+        it('can curry a function without binding any arguments', () => {
+            const curriedCombine = curry(combine);
+            expect(curriedCombine([1], [2])).toEqual([1, 2]);
+        });
+        it('can curry a function and bind 1 argument', () => {
+            const curriedCombine = curry(combine, [1]);
+            expect(curriedCombine([2])).toEqual([1, 2]);
+        });
+        it('can curry a function and bind all arguments', () => {
+            const curriedCombine = curry(combine, [1], [2]);
+            expect(curriedCombine()).toEqual([1, 2]);
+        });
+    });
+    describe('combining strings', () => {
+        const combine = (a: string, b: string) => a + b;
+        it('can curry a function without binding any arguments', () => {
+            const curriedCombine = curry(combine);
+            expect(curriedCombine('hello', 'world')).toBe('helloworld');
+        });
+        it('can curry a function and bind 1 argument', () => {
+            const curriedCombine = curry(combine, 'hello');
+            expect(curriedCombine('world')).toBe('helloworld');
+        });
+        it('can curry a function and bind all arguments', () => {
+            const curriedCombine = curry(combine, 'hello', 'world');
+            expect(curriedCombine()).toBe('helloworld');
+        });
+    });
+    describe('appending or creating arrays on objects', () => {
+        function addOrAppend(obj: { a: number; b?: string; c?: boolean; d?: string[] }, value: string) {
+            if (obj.d) {
+                return { ...obj, d: [...obj.d, value] };
+            } else {
+                return { ...obj, d: [value] };
+            }
+        }
+        function dropArray(obj: { a: number; b?: string; c?: boolean; d?: string[] }) {
+            if (obj.d) {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                const { d, ...rest } = obj;
+                return rest;
+            } else {
+                return obj;
+            }
+        }
+        it('can curry an array appending function without binding any arguments', () => {
+            const curriedAddOrAppend = curry(addOrAppend);
+            expect(curriedAddOrAppend({ a: 1 }, 'hello')).toEqual({ a: 1, d: ['hello'] });
+        });
+        it('can curry an array appending function and bind the initial object', () => {
+            const curriedAddOrAppend = curry(addOrAppend, { a: 1 });
+            expect(curriedAddOrAppend('hello')).toEqual({ a: 1, d: ['hello'] });
+            expect(curriedAddOrAppend('world')).toEqual({ a: 1, d: ['world'] });
+        });
+        it('can curry an array dropping function without binding any arguments', () => {
+            const curriedDrop = curry(dropArray);
+            expect(curriedDrop({ a: 1, d: ['hello'] })).toEqual({ a: 1 });
+        });
+        it('can curry an array dropping function and bind the initial object', () => {
+            const curriedDrop = curry(dropArray, { a: 1, d: ['hello'] });
+            expect(curriedDrop()).toEqual({ a: 1 });
+        });
+    });
+    describe('capturing errors', () => {
+        const error = (a: string) => {
+            throw new Error(a);
+        };
+        it('can curry a function without binding any arguments', () => {
+            const curriedError = curry(error);
+            expect(() => curriedError('test error')).toThrow('test error');
+        });
+        it('can curry a function and bind all arguments', () => {
+            const curriedError = curry(error, 'test error');
+            expect(() => curriedError()).toThrow('test error');
+        });
+    });
+    describe('nested curries', () => {
+        const capitalize = (a: string) => a.toUpperCase();
+        const concat = (a: string, b: string) => a + b;
+        it('can curry a function without binding any arguments', () => {
+            const curriedConcat = curry(concat);
+            const curriedCapitalize = curry(capitalize);
+            expect(curriedConcat(curriedCapitalize('hello'), 'world')).toBe('HELLOworld');
+        });
+        it('can curry a function and bind 1 argument', () => {
+            const curriedConcat = curry(concat, 'hello');
+            const curriedCapitalize = curry(capitalize);
+            expect(curriedConcat(curriedCapitalize('world'))).toBe('helloWORLD');
+        });
+    });
+    describe('async curries', () => {
+        const asyncUpper = async (a: string) => a.toUpperCase();
+        it('can curry a function without binding any arguments', async () => {
+            expect.assertions(1);
+            const curriedUpper = curry(asyncUpper);
+            await expect(curriedUpper('hello')).resolves.toBe('HELLO');
+        });
+        it('can curry a function and bind all arguments', async () => {
+            expect.assertions(1);
+            const curriedUpper = curry(asyncUpper, 'hello');
+            await expect(curriedUpper()).resolves.toBe('HELLO');
+        });
+        it('can call the curried function multiple times', async () => {
+            expect.assertions(3);
+            const curriedUpper = curry(asyncUpper);
+            await expect(curriedUpper('hello')).resolves.toBe('HELLO');
+            await expect(curriedUpper('world')).resolves.toBe('WORLD');
+            await expect(curriedUpper('again')).resolves.toBe('AGAIN');
+        });
+    });
+});

--- a/packages/functional/src/__typetests__/curry-typetest.ts
+++ b/packages/functional/src/__typetests__/curry-typetest.ts
@@ -1,0 +1,218 @@
+import { curry } from '../curry';
+
+function assertNotAProperty<T extends object, TPropName extends string>(
+    _: { [Prop in keyof T]: Prop extends TPropName ? never : T[Prop] },
+    _propName: TPropName
+): void {}
+
+// Primitives
+{
+    const fn = (a: string): string => a;
+    const curried = curry(fn);
+    curried satisfies (a: string) => string;
+}
+{
+    const fn = (a: number): string => a.toString();
+    const curried = curry(fn);
+    curried satisfies (a: number) => string;
+}
+{
+    const fn = (a: number, b: string): string => a.toString() + b;
+    const curried = curry(fn);
+    curried satisfies (a: number, b: string) => string;
+}
+{
+    const fn = (a: number, b: string, c: boolean): string => a.toString() + b + c.toString();
+    const curried = curry(fn);
+    curried satisfies (a: number, b: string, c: boolean) => string;
+}
+{
+    const fn = (a: number, b: string, c: boolean, d: number): string => a.toString() + b + c.toString() + d.toString();
+    const curried = curry(fn);
+    curried satisfies (a: number, b: string, c: boolean, d: number) => string;
+}
+{
+    const fn = (a: number, b: string, c: boolean, d: number, e: string): string =>
+        a.toString() + b + c.toString() + d.toString() + e;
+    const curried = curry(fn);
+    curried satisfies (a: number, b: string, c: boolean, d: number, e: string) => string;
+}
+{
+    const fn = (a: number, b: string, c: boolean, d: number, e: string, f: boolean): string =>
+        a.toString() + b + c.toString() + d.toString() + e + f.toString();
+    const curried = curry(fn);
+    curried satisfies (a: number, b: string, c: boolean, d: number, e: string, f: boolean) => string;
+}
+{
+    const fn = (a: number, b: string, c: boolean, d: number, e: string, f: boolean, g: number): string =>
+        a.toString() + b + c.toString() + d.toString() + e + f.toString() + g.toString();
+    const curried = curry(fn);
+    curried satisfies (a: number, b: string, c: boolean, d: number, e: string, f: boolean, g: number) => string;
+}
+{
+    const fn = (a: number, b: string, c: boolean, d: number, e: string, f: boolean, g: number, h: string): string =>
+        a.toString() + b + c.toString() + d.toString() + e + f.toString() + g.toString() + h;
+    const curried = curry(fn);
+    curried satisfies (
+        a: number,
+        b: string,
+        c: boolean,
+        d: number,
+        e: string,
+        f: boolean,
+        g: number,
+        h: string
+    ) => string;
+}
+{
+    const fn = (
+        a: number,
+        b: string,
+        c: boolean,
+        d: number,
+        e: string,
+        f: boolean,
+        g: number,
+        h: string,
+        i: boolean
+    ): string => a.toString() + b + c.toString() + d.toString() + e + f.toString() + g.toString() + h + i.toString();
+    const curried = curry(fn);
+    curried satisfies (
+        a: number,
+        b: string,
+        c: boolean,
+        d: number,
+        e: string,
+        f: boolean,
+        g: number,
+        h: string,
+        i: boolean
+    ) => string;
+}
+
+// Arrays
+{
+    const fn = (a: string[]): string => a.join('');
+    const curried = curry(fn);
+    curried satisfies (a: string[]) => string;
+}
+{
+    const fn = (a: number[]): string => a.join('');
+    const curried = curry(fn);
+    curried satisfies (a: number[]) => string;
+}
+{
+    const fn = (a: number[], b: number): number[] => a.map(x => x + b);
+    const curried = curry(fn);
+    curried satisfies (a: number[], b: number) => number[];
+}
+{
+    const fn = (a: number[], b: string[]): string => a.join('') + b.join('');
+    const curried = curry(fn);
+    curried satisfies (a: number[], b: string[]) => string;
+}
+
+// Objects
+{
+    const fn = (a: { a: string }): string => a.a;
+    const curried = curry(fn);
+    curried satisfies (a: { a: string }) => string;
+}
+{
+    const fn = (a: { a: number }): string => a.a.toString();
+    const curried = curry(fn);
+    curried satisfies (a: { a: number }) => string;
+}
+{
+    const fn = (a: { a: number }, b: number): number => a.a + b;
+    const curried = curry(fn);
+    curried satisfies (a: { a: number }, b: number) => number;
+}
+
+// Functions that change objects to new objects
+{
+    const fn = (a: { a: number }): { a: string } => ({ a: a.a.toString() });
+    const curried = curry(fn);
+    curried satisfies (a: { a: number }) => { a: string };
+}
+{
+    const fn = (a: { a: number }, b: { b: string }): { a: string; b: number } => ({
+        a: a.a.toString(),
+        b: parseInt(b.b, 10),
+    });
+    const curried = curry(fn);
+    curried satisfies (a: { a: number }, b: { b: string }) => { a: string; b: number };
+}
+
+// Functions that combine objects
+{
+    const fn = (a: { a: number }, b: { b: string }): { a: number; b: string } => ({ ...a, ...b });
+    const curried = curry(fn);
+    curried satisfies (a: { a: number }, b: { b: string }) => { a: number; b: string };
+}
+{
+    const fn = (a: { a: number }, b: { b: string }, c: { c: boolean }): { a: number; b: string; c: boolean } => ({
+        ...a,
+        ...b,
+        ...c,
+    });
+    const curried = curry(fn);
+    curried satisfies (a: { a: number }, b: { b: string }, c: { c: boolean }) => { a: number; b: string; c: boolean };
+}
+
+// Functions that append or create arrays on objects
+function addOrAppend(obj: { a: number; b?: string; c?: boolean; d?: string[] }, value: string) {
+    if (obj.d) {
+        return { ...obj, d: [...obj.d, value] };
+    } else {
+        return { ...obj, d: [value] };
+    }
+}
+function dropArray(obj: { a: number; b?: string; c?: boolean; d?: string[] }) {
+    if (obj.d) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { d, ...rest } = obj;
+        return rest;
+    } else {
+        return obj;
+    }
+}
+{
+    const fn = (a: { a: number }, b: string): { a: number; d: string[] } => addOrAppend(a, b);
+    const curried = curry(fn);
+    curried satisfies (a: { a: number }, b: string) => { a: number; d: string[] };
+}
+{
+    const fn = (a: { a: number }, b: string, c: boolean): { a: number; d: string[]; c: boolean } => ({
+        ...addOrAppend(a, b),
+        c,
+    });
+    const curried = curry(fn);
+    curried satisfies (a: { a: number }, b: string, c: boolean) => { a: number; d: string[]; c: boolean };
+}
+{
+    const fn = (a: { a: number; d: string[] }): { a: number } => dropArray(a);
+    const curried = curry(fn);
+    curried satisfies (a: { a: number; d: string[] }) => { a: number };
+    assertNotAProperty(curried.arguments, 'd');
+}
+
+// Nested curry
+{
+    const fn = (a: number, b: string): string => a.toString() + b;
+    const curried = curry(fn);
+    const curried2 = curry(curried);
+    curried2 satisfies (a: number, b: string) => string;
+}
+{
+    const fn = (a: number, b: string): string => a.toString() + b;
+    const curried = curry(fn);
+    const curried2 = curry(curried, 1);
+    curried2 satisfies (b: string) => string;
+}
+{
+    const fn = (a: number, b: string): string => a.toString() + b;
+    const curried = curry(fn);
+    const curried2 = curry(curried, 1, 'hello');
+    curried2 satisfies () => string;
+}

--- a/packages/functional/src/curry.ts
+++ b/packages/functional/src/curry.ts
@@ -1,0 +1,382 @@
+/**
+ * General curry function.
+ *
+ * The largest arity present in all `@solana` packages belongs to `pipe`,
+ * which supports arity of 10. Thus `curry` also supports arity of 10.
+ * @see https://github.com/solana-labs/solana-web3.js/blob/master/packages/functional/src/pipe.ts
+ *
+ * Using this function you can curry any function, binding any number of arguments.
+ * ```typescript
+ * // Using some defined function
+ * const add = (a: number, b: number) => a + b;
+ * // You can curry in one line
+ * const sum = curry(add)(1, 2);    // 3
+ * // Or you can curry with a variable
+ * const addStuff = curry(add);
+ * const sum = addStuff(1, 2);      // 3
+ * // You can also bind some arguments
+ * const addOne = curry(add, 1);
+ * const sum = addOne(2);           // 3
+ * // Or bind all arguments
+ * const addOneAndTwo = curry(add, 1, 2);
+ * const sum = addOneAndTwo();      // 3
+ * ```
+ * @param fn    The function to be curried
+ * @param args  Any default arguments to bind to the function
+ * @returns     The curried function
+ */
+export function curry<R>(fn: () => R): () => R;
+// 1 arg
+export function curry<A, R>(fn: (a: A) => R): (a: A) => R;
+export function curry<A, R>(fn: (a: A) => R, a: A): () => R;
+// 2 args
+export function curry<A, B, R>(fn: (a: A, b: B) => R): (a: A, b: B) => R;
+export function curry<A, B, R>(fn: (a: A, b: B) => R, a: A): (b: B) => R;
+export function curry<A, B, R>(fn: (a: A, b: B) => R, a: A, b: B): () => R;
+// 3 args
+export function curry<A, B, C, R>(fn: (a: A, b: B, c: C) => R): (a: A, b: B, c: C) => R;
+export function curry<A, B, C, R>(fn: (a: A, b: B, c: C) => R, a: A): (b: B, c: C) => R;
+export function curry<A, B, C, R>(fn: (a: A, b: B, c: C) => R, a: A, b: B): (c: C) => R;
+export function curry<A, B, C, R>(fn: (a: A, b: B, c: C) => R, a: A, b: B, c: C): () => R;
+// 4 args
+export function curry<A, B, C, D, R>(fn: (a: A, b: B, c: C, d: D) => R): (a: A, b: B, c: C, d: D) => R;
+export function curry<A, B, C, D, R>(fn: (a: A, b: B, c: C, d: D) => R, a: A): (b: B, c: C, d: D) => R;
+export function curry<A, B, C, D, R>(fn: (a: A, b: B, c: C, d: D) => R, a: A, b: B): (c: C, d: D) => R;
+export function curry<A, B, C, D, R>(fn: (a: A, b: B, c: C, d: D) => R, a: A, b: B, c: C): (d: D) => R;
+export function curry<A, B, C, D, R>(fn: (a: A, b: B, c: C, d: D) => R, a: A, b: B, c: C, d: D): () => R;
+// 5 args
+export function curry<A, B, C, D, E, R>(fn: (a: A, b: B, c: C, d: D, e: E) => R): (a: A, b: B, c: C, d: D, e: E) => R;
+export function curry<A, B, C, D, E, R>(fn: (a: A, b: B, c: C, d: D, e: E) => R, a: A): (b: B, c: C, d: D, e: E) => R;
+export function curry<A, B, C, D, E, R>(fn: (a: A, b: B, c: C, d: D, e: E) => R, a: A, b: B): (c: C, d: D, e: E) => R;
+export function curry<A, B, C, D, E, R>(fn: (a: A, b: B, c: C, d: D, e: E) => R, a: A, b: B, c: C): (d: D, e: E) => R;
+export function curry<A, B, C, D, E, R>(fn: (a: A, b: B, c: C, d: D, e: E) => R, a: A, b: B, c: C, d: D): (e: E) => R;
+export function curry<A, B, C, D, E, R>(fn: (a: A, b: B, c: C, d: D, e: E) => R, a: A, b: B, c: C, d: D, e: E): () => R;
+// 6 args
+export function curry<A, B, C, D, E, F, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F) => R
+): (a: A, b: B, c: C, d: D, e: E, f: F) => R;
+export function curry<A, B, C, D, E, F, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F) => R,
+    a: A
+): (b: B, c: C, d: D, e: E, f: F) => R;
+export function curry<A, B, C, D, E, F, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F) => R,
+    a: A,
+    b: B
+): (c: C, d: D, e: E, f: F) => R;
+export function curry<A, B, C, D, E, F, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F) => R,
+    a: A,
+    b: B,
+    c: C
+): (d: D, e: E, f: F) => R;
+export function curry<A, B, C, D, E, F, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D
+): (e: E, f: F) => R;
+export function curry<A, B, C, D, E, F, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E
+): (f: F) => R;
+export function curry<A, B, C, D, E, F, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F
+): () => R;
+// 7 args
+export function curry<A, B, C, D, E, F, G, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => R
+): (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => R;
+export function curry<A, B, C, D, E, F, G, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => R,
+    a: A
+): (b: B, c: C, d: D, e: E, f: F, g: G) => R;
+export function curry<A, B, C, D, E, F, G, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => R,
+    a: A,
+    b: B
+): (c: C, d: D, e: E, f: F, g: G) => R;
+export function curry<A, B, C, D, E, F, G, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => R,
+    a: A,
+    b: B,
+    c: C
+): (d: D, e: E, f: F, g: G) => R;
+export function curry<A, B, C, D, E, F, G, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D
+): (e: E, f: F, g: G) => R;
+export function curry<A, B, C, D, E, F, G, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E
+): (f: F, g: G) => R;
+export function curry<A, B, C, D, E, F, G, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F
+): (g: G) => R;
+export function curry<A, B, C, D, E, F, G, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G
+): () => R;
+// 8 args
+export function curry<A, B, C, D, E, F, G, H, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R
+): (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R;
+export function curry<A, B, C, D, E, F, G, H, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R,
+    a: A
+): (b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R;
+export function curry<A, B, C, D, E, F, G, H, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R,
+    a: A,
+    b: B
+): (c: C, d: D, e: E, f: F, g: G, h: H) => R;
+export function curry<A, B, C, D, E, F, G, H, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R,
+    a: A,
+    b: B,
+    c: C
+): (d: D, e: E, f: F, g: G, h: H) => R;
+export function curry<A, B, C, D, E, F, G, H, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D
+): (e: E, f: F, g: G, h: H) => R;
+export function curry<A, B, C, D, E, F, G, H, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E
+): (f: F, g: G, h: H) => R;
+export function curry<A, B, C, D, E, F, G, H, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F
+): (g: G, h: H) => R;
+export function curry<A, B, C, D, E, F, G, H, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G
+): (h: H) => R;
+export function curry<A, B, C, D, E, F, G, H, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H
+): () => R;
+// 9 args
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R
+): (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R;
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R,
+    a: A
+): (b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R;
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R,
+    a: A,
+    b: B
+): (c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R;
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R,
+    a: A,
+    b: B,
+    c: C
+): (d: D, e: E, f: F, g: G, h: H, i: I) => R;
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D
+): (e: E, f: F, g: G, h: H, i: I) => R;
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E
+): (f: F, g: G, h: H, i: I) => R;
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F
+): (g: G, h: H, i: I) => R;
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G
+): (h: H, i: I) => R;
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H
+): (i: I) => R;
+export function curry<A, B, C, D, E, F, G, H, I, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I
+): () => R;
+// 10 args
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R
+): (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A
+): (b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A,
+    b: B
+): (c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A,
+    b: B,
+    c: C
+): (d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D
+): (e: E, f: F, g: G, h: H, i: I, j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E
+): (f: F, g: G, h: H, i: I, j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F
+): (g: G, h: H, i: I, j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G
+): (h: H, i: I, j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H
+): (i: I, j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I
+): (j: J) => R;
+export function curry<A, B, C, D, E, F, G, H, I, J, R>(
+    fn: (a: A, b: B, c: C, d: D, e: E, f: F, g: G, h: H, i: I, j: J) => R,
+    a: A,
+    b: B,
+    c: C,
+    d: D,
+    e: E,
+    f: F,
+    g: G,
+    h: H,
+    i: I,
+    j: J
+): () => R;
+// Implementation
+export function curry(fn: (...args: unknown[]) => unknown, ...args: unknown[]) {
+    return fn.bind(null, ...args);
+}

--- a/packages/functional/src/index.ts
+++ b/packages/functional/src/index.ts
@@ -1,1 +1,2 @@
+export * from './curry';
 export * from './pipe';


### PR DESCRIPTION
This PR adds the `curry` function to the `@solana/functional` library.

This function is analogous to using JavaScript's `.bind(..)` on a function, however, it provides a more intuitive and simpler approach to performing function currying.

```javascript
const add = (a: number, b: number) => a + b;
// Using bind
const addOneWithBind = add.bind(null, 1);
addOneWithBind(2); // 3
// Using curry
const addOneWithCurry = curry(add, 1);
addOneWithCurry(2); // 3
```

Motivation: most people may not really know how to use `bind`, and seeing `curry` in an example could be more intuitive to most.