### PR TITLE
feat(experimental): add curry with pipe tests for demonstration

### DIFF
--- a/packages/functional/src/__tests__/curry-pipe-test.ts
+++ b/packages/functional/src/__tests__/curry-pipe-test.ts
@@ -1,0 +1,30 @@
+import { curry } from '../curry';
+import { pipe } from '../pipe';
+
+describe('curry and pipe', () => {
+    it('can build a pipe with curried functions', () => {
+        const add = (a: number, b: number) => a + b;
+        const addOne = curry(add, 1);
+        expect(pipe(1, addOne, addOne)).toBe(3);
+    });
+    it('can pipe multiple different curried functions', () => {
+        const add = (a: number, b: number) => a + b;
+        const addOne = curry(add, 1);
+        const addTwo = curry(add, 2);
+        expect(pipe(1, addOne, addTwo)).toBe(4);
+    });
+    it('can build a nested pipe with curried functions', () => {
+        const add = (a: number, b: number) => a + b;
+        const addOne = curry(add, 1);
+        const addTwo = curry(add, 2);
+        expect(pipe(pipe(1, addOne, addTwo), addOne, addTwo)).toBe(7);
+    });
+    it('can curry a pipe', () => {
+        const add = (a: number, b: number) => a + b;
+        const addOne = curry(add, 1);
+        const addTwo = curry(add, 2);
+        const pipedAdd = (startNumber: number) => pipe(startNumber, addOne, addTwo);
+        const curriedPipedAdd = curry(pipedAdd);
+        expect(curriedPipedAdd(1)).toBe(4);
+    });
+});

--- a/packages/functional/src/__typetests__/curry-pipe-typetest.ts
+++ b/packages/functional/src/__typetests__/curry-pipe-typetest.ts
@@ -1,0 +1,28 @@
+import { curry } from '../curry';
+import { pipe } from '../pipe';
+
+{
+    const add = (a: number, b: number) => a + b;
+    const addOne = curry(add, 1);
+    pipe(1, addOne, addOne) satisfies number;
+}
+{
+    const add = (a: number, b: number) => a + b;
+    const addOne = curry(add, 1);
+    const addTwo = curry(add, 2);
+    pipe(1, addOne, addTwo) satisfies number;
+}
+{
+    const add = (a: number, b: number) => a + b;
+    const addOne = curry(add, 1);
+    const addTwo = curry(add, 2);
+    pipe(pipe(1, addOne, addTwo), addOne, addTwo) satisfies number;
+}
+{
+    const add = (a: number, b: number) => a + b;
+    const addOne = curry(add, 1);
+    const addTwo = curry(add, 2);
+    const pipedAdd = (startNumber: number) => pipe(startNumber, addOne, addTwo);
+    const curriedPipedAdd = curry(pipedAdd);
+    curriedPipedAdd(1) satisfies number;
+}


### PR DESCRIPTION
This PR adds a few tests to demonstrate using `pipe` and `curry` together, which is likely a common pattern for building transactions with the new experimental API.