### PR TITLE
fix: peg test validator version to latest 1.14.x

### DIFF
--- a/scripts/get-latest-validator-release-version.sh
+++ b/scripts/get-latest-validator-release-version.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 (
     set -e
-    version=$(curl -s -N https://api.github.com/repos/solana-labs/solana/releases/latest \
-      | grep -m 1 \"tag_name\" \
-      | sed -ne 's/^ *"tag_name": "\([^"]*\)",$/\1/p')
+    version=$(curl -s "https://api.github.com/repos/solana-labs/solana/releases" | \
+      grep '"tag_name": "v1.14.' | \
+      sort -t. -k3,3nr | \
+      head -n1 | \
+      awk -F\" '{print $4}')
     if [ -z $version ]; then
       exit 3
     fi

--- a/scripts/setup-test-validator.sh
+++ b/scripts/setup-test-validator.sh
@@ -5,8 +5,10 @@ set -ex
 TARGET_DIR=$( cd "$(dirname "${BASH_SOURCE[0]}")/.." ; pwd -P )/.solana
 
 # setup environment
-version=$(curl -s -N https://api.github.com/repos/solana-labs/solana/releases/latest \
-    | grep -m 1 \"tag_name\" \
-    | sed -ne 's/^ *"tag_name": "\([^"]*\)",$/\1/p')
+version=$(curl -s "https://api.github.com/repos/solana-labs/solana/releases" | \
+    grep '"tag_name": "v1.14.' | \
+    sort -t. -k3,3nr | \
+    head -n1 | \
+    awk -F\" '{print $4}')
 sh -c "$(curl -sSfL https://release.solana.com/$version/install)" init $version --data-dir $TARGET_DIR --no-modify-path
 $TARGET_DIR/active_release/bin/solana --version


### PR DESCRIPTION
Until we can update `@solana/rpc-core` to support the latest minor version on `mainnet-beta`, we'll have to keep the test validator on `1.14.x` to avoid our tests exploding.

This PR fixes the version to the latest `1.14.x` release.

See #1634 