### PR TITLE
Add memoizeWithNoParams function to @solana/functional

### DIFF
--- a/packages/functional/src/__tests__/memoize-test.ts
+++ b/packages/functional/src/__tests__/memoize-test.ts
@@ -1,0 +1,18 @@
+import { memoizeWithNoParams } from "../memoize";
+
+describe('memoizeWithNoParams', () => {
+  it('returns a function that returns result of the memoized function', () => {
+    const fn = () => 1;
+    const memoized = memoizeWithNoParams(fn);
+    expect(memoized()).toEqual(1);
+  })
+
+  it('only calls the function once if it is called repeatedly', () => {
+    const fn = jest.fn().mockReturnValue(1);
+
+    const memoized = memoizeWithNoParams(fn);
+    expect(memoized()).toEqual(1);
+    expect(memoized()).toEqual(1);
+    expect(fn).toHaveBeenCalledTimes(1);
+  })
+});

--- a/packages/functional/src/index.ts
+++ b/packages/functional/src/index.ts
@@ -1,1 +1,2 @@
+export * from './memoize';
 export * from './pipe';

--- a/packages/functional/src/memoize.ts
+++ b/packages/functional/src/memoize.ts
@@ -1,0 +1,11 @@
+const sentinel: unique symbol = Symbol();
+
+export function memoizeWithNoParams(f: Function) {
+  let result: any = sentinel;
+  return function () {
+    if (result === sentinel) {
+      result = f.call(null);
+    }
+    return result;
+  };
+}


### PR DESCRIPTION
This PR adds a new `memoizeWithNoParams` function to `@solana/functional`

It can be used to automatically memoize any function that does not require any params when called
