### PR TITLE
refactor(experimental-graphql): introduce custom parsing extension

### DIFF
--- a/packages/rpc-graphql/src/__tests__/__setup__.ts
+++ b/packages/rpc-graphql/src/__tests__/__setup__.ts
@@ -1604,6 +1604,71 @@ export const mockTransactionVote = {
     },
 };
 
+export const mockTransactionCreateBet = {
+    blockTime: 1699618507,
+    meta: {
+        computeUnitsConsumed: 53355,
+        err: null,
+        fee: 5000,
+        innerInstructions: [],
+        logMessages: [],
+        postBalances: [113383490000, 23942400, 1169280, 1141440],
+        postTokenBalances: [],
+        preBalances: [113383495000, 23942400, 1169280, 1141440],
+        preTokenBalances: [],
+        rewards: [],
+        status: {
+            Ok: null,
+        },
+    },
+    slot: 257318391,
+    transaction: {
+        message: {
+            accountKeys: [
+                {
+                    pubkey: 'HUZu4xMSHbxTWbkXR6jkGdjvDPJLjrpSNXSoUFBRgjWs',
+                    signer: true,
+                    source: 'transaction',
+                    writable: true,
+                },
+                {
+                    pubkey: '3LuSbvThg5STSvcqTFNG74pifPs9cz2kT6msLA7trkiz',
+                    signer: false,
+                    source: 'transaction',
+                    writable: true,
+                },
+                {
+                    pubkey: 'SysvarC1ock11111111111111111111111111111111',
+                    signer: false,
+                    source: 'transaction',
+                    writable: false,
+                },
+                {
+                    pubkey: 'gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s',
+                    signer: false,
+                    source: 'transaction',
+                    writable: false,
+                },
+            ],
+            instructions: [
+                {
+                    accounts: [
+                        'HUZu4xMSHbxTWbkXR6jkGdjvDPJLjrpSNXSoUFBRgjWs',
+                        'DMyZyzfNR1uhqYcFGrNftirkveCbyNVLnCB8HgShYz4V',
+                        'SysvarC1ock11111111111111111111111111111111',
+                    ],
+                    data: '6mJFQCt94hG4CKNYKgVcwo7gRuVPWDv2unmQd4jq8zWK3wQZG54k2b',
+                    programId: 'gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s',
+                    stackHeight: null,
+                },
+            ],
+            recentBlockhash: 'ETbinvUP8hqHssm4wHePZnEYupJncfuqn8YdY9uKkYow',
+        },
+        signatures: ['DC4yP5xEUhHuzSDq8fk2TznnMxy4DJm4M5qSzmnuPngLtnn8jH8qu4MEjmie2piiksEGwe98CawKUHuR7VQJ1Nt'],
+    },
+    version: 'legacy',
+};
+
 const mockRewards = [
     {
         commission: 0.1,

--- a/packages/rpc-graphql/src/__tests__/ast-test.ts
+++ b/packages/rpc-graphql/src/__tests__/ast-test.ts
@@ -1,0 +1,280 @@
+import { Signature } from '@solana/keys';
+import { createSolanaRpcApi, SolanaRpcMethods } from '@solana/rpc-core';
+import { createHttpTransport, createJsonRpc } from '@solana/rpc-transport';
+import { Rpc } from '@solana/rpc-transport/dist/types/json-rpc-types';
+import { Base64EncodedWireTransaction } from '@solana/transactions';
+import fetchMock from 'jest-fetch-mock-fork';
+
+import { createRpcGraphQL, RpcGraphQL } from '../rpc';
+import {
+    getCryptoKeyPairWithAirdrop,
+    getMockTransactionReturnData,
+    mockRpcResponse,
+    mockTransactionCreateBet,
+} from './__setup__';
+
+const programAst = [
+    /* JSON */ `
+{
+    "instructions": [
+        {
+            "name": "CreateBet",
+            "type": {
+                "fields": [
+                    {
+                        "name": "amount",
+                        "type": "u64",
+                    },
+                    {
+                        "name": "letItRide",
+                        "type": "boolean",
+                    },
+                    {
+                        "name": "riskAppetite",
+                        "type": "u8",
+                    },
+                    {
+                        "name": "team",
+                        "type": "string",
+                    },
+                    {
+                        "name": "username",
+                        "type": "string",
+                    },
+                ],
+                "kind": "struct",
+            },
+        }
+    ],
+    "accounts": [
+        {
+            "name": "TokenMetadata",
+            "type": {
+                "fields": [
+                    {
+                        "name": "title",
+                        "type": "string",
+                    },
+                    {
+                        "name": "symbol",
+                        "type": "string",
+                    },
+                    {
+                        "name": "uri",
+                        "type": "string",
+                    },
+                    {
+                        "name": "mint",
+                        "type": "publicKey",
+                    },
+                    {
+                        "name": "mintAuthority",
+                        "type": "publicKey",
+                    },
+                ],
+                "kind": "struct",
+            },
+        }
+    ],
+    "types": [
+        {
+            "name": "Asset",
+            "type": {
+                "fields": [
+                    {
+                        "name": "assetSize",
+                        "type": "u32",
+                    },
+                    {
+                        "name": "assetType",
+                        "type": "string",
+                    },
+                ],
+                "kind": "struct",
+            },
+        }
+    ],
+}
+`,
+];
+
+describe('codecs', () => {
+    let rpc: Rpc<SolanaRpcMethods>;
+    let rpcGraphQL: RpcGraphQL;
+
+    // Random signature for testing.
+    // Not actually used. Just needed for proper query parsing.
+    const defaultTransactionSignature =
+        '67rSZV97NzE4B4ZeFqULqWZcNEV2KwNfDLMzecJmBheZ4sWhudqGAzypoBCKfeLkKtDQBGnkwgdrrFM8ZMaS3pkk' as Signature;
+    let feePayer: CryptoKeyPair;
+    let base64ReturnDataTransaction: Base64EncodedWireTransaction;
+
+    beforeAll(async () => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+        feePayer = await getCryptoKeyPairWithAirdrop(rpc);
+        base64ReturnDataTransaction = await getMockTransactionReturnData(rpc, feePayer);
+    });
+
+    beforeEach(() => {
+        fetchMock.resetMocks();
+        fetchMock.dontMock();
+        rpc = createJsonRpc<SolanaRpcMethods>({
+            api: createSolanaRpcApi(),
+            transport: createHttpTransport({ url: 'http://127.0.0.1:8899' }),
+        });
+        rpcGraphQL = createRpcGraphQL(rpc, { programAst });
+    });
+
+    describe('accounts', () => {
+        it('can get a `TokenMetadata` account', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/token-metadata-account.json
+            const variableValues = {
+                address: 'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
+            };
+            const source = /* GraphQL */ `
+                query testQuery($address: String!) {
+                    account(address: $address) {
+                        address
+                        lamports
+                        ownerProgram {
+                            address
+                        }
+                        rentEpoch
+                        space
+                        ... on TokenMetadataAccount {
+                            title
+                            symbol
+                            uri
+                            mint {
+                                address
+                            }
+                            mintAuthority {
+                                address
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        address: 'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
+                        blockhash: expect.any(String),
+                        feeCalculator: {
+                            lamportsPerSignature: expect.any(String),
+                        },
+                        lamports: expect.any(BigInt),
+                        mint: {
+                            address: '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe',
+                        },
+                        mintAuthority: {
+                            address: '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe',
+                        },
+                        ownerProgram: {
+                            address: '11111111111111111111111111111111',
+                        },
+                        rentEpoch: expect.any(BigInt),
+                        space: 80n,
+                        symbol: 'SOL',
+                        title: 'Solana',
+                        uri: 'https://solana.com',
+                    },
+                },
+            });
+        });
+    });
+    describe('instructions', () => {
+        it('can get a `CreateBet` instruction', async () => {
+            expect.assertions(1);
+            fetchMock.mockOnce(JSON.stringify(mockRpcResponse(mockTransactionCreateBet)));
+            const source = /* GraphQL */ `
+                query testQuery {
+                    transaction(signature: "${defaultTransactionSignature}") {
+                        ... on TransactionParsed {
+                            meta {
+                                innerInstructions {
+                                    instructions {
+                                            programId
+                                        ... on CreateBetInstruction {
+                                            amount
+                                            letItRide
+                                            riskAppetite
+                                            team
+                                            username
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source);
+            expect(result).toMatchObject({
+                data: {
+                    transaction: {
+                        meta: {
+                            innerInstructions: expect.arrayContaining([
+                                {
+                                    instructions: expect.arrayContaining([
+                                        {
+                                            amount: expect.any(BigInt),
+                                            letItRide: false,
+                                            programId: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                            riskAppetite: 0,
+                                            team: 'Team A',
+                                            username: 'Alice',
+                                        },
+                                    ]),
+                                },
+                            ]),
+                        },
+                    },
+                },
+            });
+        });
+    });
+    describe('return data', () => {
+        it('can get an `Asset` return data', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testSimulate($transaction: String!) {
+                    simulate(transaction: $transaction) {
+                        err
+                        logs
+                        returnData {
+                            programId
+                            ... on AssetReturnData {
+                                assetSize
+                                assetType
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, {
+                transaction: base64ReturnDataTransaction,
+            });
+            expect(result).toMatchObject({
+                data: {
+                    simulate: {
+                        err: null,
+                        logs: expect.any(Array),
+                        returnData: {
+                            assetSize: 100,
+                            assetType: 'PNG',
+                            programId: '7aF53SYcGeBw2FsUKiCqWR5m1ABZ9qsTXxLoD5NRqaS8',
+                        },
+                    },
+                },
+            });
+        });
+    });
+});

--- a/packages/rpc-graphql/src/rpc.ts
+++ b/packages/rpc-graphql/src/rpc.ts
@@ -8,6 +8,7 @@ import { graphql, GraphQLSchema, Source } from 'graphql';
 
 import { createSolanaGraphQLContext, RpcGraphQLContext } from './context';
 import { createSolanaGraphQLSchema } from './schema';
+import { ProgramAstSource } from './schema/ast/types';
 
 type RpcMethods = GetAccountInfoApi & GetBlockApi & GetProgramAccountsApi & GetTransactionApi & SimulateTransactionApi;
 
@@ -20,9 +21,13 @@ export interface RpcGraphQL {
     schema: GraphQLSchema;
 }
 
-export function createRpcGraphQL(rpc: Rpc<RpcMethods>): RpcGraphQL {
+type RpcGraphQLConfig = Readonly<{
+    programAst: ProgramAstSource[];
+}>;
+
+export function createRpcGraphQL(rpc: Rpc<RpcMethods>, config?: RpcGraphQLConfig): RpcGraphQL {
     const context = createSolanaGraphQLContext(rpc);
-    const schema = createSolanaGraphQLSchema();
+    const schema = createSolanaGraphQLSchema({ ...config });
     return {
         context,
         async query(source: string | Source, variableValues?: { readonly [variable: string]: unknown }) {

--- a/packages/rpc-graphql/src/schema/ast/decoders.ts
+++ b/packages/rpc-graphql/src/schema/ast/decoders.ts
@@ -1,0 +1,52 @@
+import { getBooleanCodec, getBytesCodec, getStructCodec } from '@solana/codecs-data-structures';
+import { getU8Codec, getU16Codec, getU32Codec, getU64Codec, getU128Codec } from '@solana/codecs-numbers';
+import { getBase58Codec, getBase64Codec, getStringCodec } from '@solana/codecs-strings';
+
+import { FieldType, ProgramAstType } from './types';
+
+function buildFieldCodec(type: FieldType) {
+    switch (type) {
+        case 'boolean':
+            return getBooleanCodec();
+        case 'string':
+            return getStringCodec();
+        case 'u8':
+            return getU8Codec();
+        case 'u16':
+            return getU16Codec();
+        case 'u32':
+            return getU32Codec();
+        case 'u64':
+            return getU64Codec();
+        case 'u128':
+            return getU128Codec();
+        case 'publicKey':
+            return getBytesCodec({ size: 32 });
+    }
+}
+
+function buildStructCodec(astType: ProgramAstType) {
+    return getStructCodec(
+        astType.type.fields.map(field => [field.name, buildFieldCodec(field.type)]) as Parameters<
+            typeof getStructCodec
+        >[0]
+    );
+}
+
+function getCodecForEncoding(encoding: 'base58' | 'base64' | string) {
+    switch (encoding) {
+        case 'base58':
+            return getBase58Codec();
+        case 'base64':
+            return getBase64Codec();
+        default:
+            throw new Error(`Unsupported encoding for codecs: ${encoding}`);
+    }
+}
+
+/* Transform encoded data into the parsed type */
+export function buildDecoder(astType: ProgramAstType) {
+    const structDecoder = buildStructCodec(astType);
+    return (data: string, encoding: 'base58' | 'base64') =>
+        structDecoder.decode(getCodecForEncoding(encoding).encode(data));
+}

--- a/packages/rpc-graphql/src/schema/ast/index.ts
+++ b/packages/rpc-graphql/src/schema/ast/index.ts
@@ -1,0 +1,50 @@
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+import { buildAccountGraphQLTypeDef, buildInstructionGraphQLTypeDef, buildTypeGraphQLTypeDef } from './type-defs';
+import { ProgramAst, ProgramAstSource } from './types';
+
+export interface AstConfig {
+    resolvers: Record<string, unknown>;
+    typeDefs: string;
+    resolveTypeExtension?: (obj: unknown) => string;
+}
+
+export interface SchemaAstConfig {
+    accounts: AstConfig;
+    instructions: AstConfig;
+    types: AstConfig;
+}
+
+function buildSchemaAstConfig(programAst: ProgramAstSource): SchemaAstConfig {
+    const parsedAst: ProgramAst = typeof programAst === 'string' ? JSON.parse(programAst) : programAst;
+    return {
+        accounts: {
+            resolvers: {},
+            typeDefs: parsedAst.accounts.map(buildAccountGraphQLTypeDef).join('\n'),
+            // TODO: Conditional function for mapping decoded data.
+            resolveTypeExtension: (_account): string => null as unknown as string,
+        },
+        instructions: {
+            resolvers: {},
+            typeDefs: parsedAst.instructions.map(buildInstructionGraphQLTypeDef).join('\n'),
+            // TODO: Conditional function for mapping decoded data.
+            resolveTypeExtension: (_instruction): string => null as unknown as string,
+        },
+        types: {
+            resolvers: {},
+            typeDefs: parsedAst.types.map(buildTypeGraphQLTypeDef).join('\n'),
+        },
+    };
+}
+
+export function buildAstSchemaConfig(programAst: ProgramAstSource[]): SchemaAstConfig {
+    // TODO: This isn't going to work.
+    return programAst.map(buildSchemaAstConfig).reduce((acc, cur) => {
+        acc.accounts.resolvers = { ...acc.accounts.resolvers, ...cur.accounts.resolvers };
+        acc.accounts.typeDefs += cur.accounts.typeDefs;
+        acc.instructions.resolvers = { ...acc.instructions.resolvers, ...cur.instructions.resolvers };
+        acc.instructions.typeDefs += cur.instructions.typeDefs;
+        acc.types.resolvers = { ...acc.types.resolvers, ...cur.types.resolvers };
+        acc.types.typeDefs += cur.types.typeDefs;
+        return acc;
+    });
+}

--- a/packages/rpc-graphql/src/schema/ast/type-defs.ts
+++ b/packages/rpc-graphql/src/schema/ast/type-defs.ts
@@ -1,0 +1,52 @@
+import { FieldType, ProgramAstType } from './types';
+
+function buildFieldGraphQLTypeDef(type: FieldType) {
+    switch (type) {
+        case 'boolean':
+            return 'Boolean';
+        case 'string':
+            return 'String';
+        case 'u8':
+        case 'u16':
+        case 'u32':
+            return 'Int';
+        case 'u64':
+        case 'u128':
+            return 'BigInt';
+        case 'publicKey':
+            return 'Address';
+    }
+}
+
+export function buildAccountGraphQLTypeDef(accountAst: ProgramAstType) {
+    const fields = accountAst.type.fields
+        .map(field => `${field.name}: ${buildFieldGraphQLTypeDef(field.type)}`)
+        .join('\n');
+    return /* GraphQL */ `
+        type ${accountAst.name} implements Account {
+            ${fields}
+        }
+    `;
+}
+
+export function buildInstructionGraphQLTypeDef(instructionAst: ProgramAstType) {
+    const fields = instructionAst.type.fields
+        .map(field => `${field.name}: ${buildFieldGraphQLTypeDef(field.type)}`)
+        .join('\n');
+    return /* GraphQL */ `
+        type ${instructionAst.name} implements TransactionInstruction {
+            ${fields}
+        }
+    `;
+}
+
+export function buildTypeGraphQLTypeDef(typeAst: ProgramAstType) {
+    const fields = typeAst.type.fields
+        .map(field => `${field.name}: ${buildFieldGraphQLTypeDef(field.type)}`)
+        .join('\n');
+    return /* GraphQL */ `
+        type ${typeAst.name} implements TransactionInstruction {
+            ${fields}
+        }
+    `;
+}

--- a/packages/rpc-graphql/src/schema/ast/types.ts
+++ b/packages/rpc-graphql/src/schema/ast/types.ts
@@ -1,0 +1,23 @@
+export type FieldType = 'boolean' | 'string' | 'u8' | 'u16' | 'u32' | 'u64' | 'u128' | 'publicKey';
+
+export interface Field {
+    name: string;
+    type: FieldType;
+}
+
+export interface ProgramAstType {
+    name: string;
+    type: {
+        fields: Field[];
+        kind: 'struct';
+    };
+}
+
+/* IDL/Kinobi Tree */
+export interface ProgramAst {
+    accounts: ProgramAstType[];
+    instructions: ProgramAstType[];
+    types: ProgramAstType[];
+}
+
+export type ProgramAstSource = string | ProgramAst;

--- a/packages/rpc-graphql/src/schema/common/types.ts
+++ b/packages/rpc-graphql/src/schema/common/types.ts
@@ -1,6 +1,7 @@
 import { resolveAccount } from '../../resolvers/account';
+import { AstConfig } from '../ast';
 
-export const commonTypeDefs = /* GraphQL */ `
+const commonTypeDefs = /* GraphQL */ `
     enum AccountEncoding {
         BASE_58
         BASE_64
@@ -66,7 +67,7 @@ export const commonTypeDefs = /* GraphQL */ `
     }
 `;
 
-export const commonResolvers = {
+const commonResolvers = {
     AccountEncoding: {
         BASE_58: 'base58',
         BASE_64: 'base64',
@@ -87,3 +88,9 @@ export const commonResolvers = {
         ZERO: 0,
     },
 };
+
+export function buildCommonSchema(types?: AstConfig): [Record<string, unknown>, string] {
+    return types
+        ? [{ ...commonResolvers, ...types.resolvers }, [commonTypeDefs, ...types.typeDefs].join('\n')]
+        : [commonResolvers, commonTypeDefs];
+}

--- a/packages/rpc-graphql/src/schema/instruction.ts
+++ b/packages/rpc-graphql/src/schema/instruction.ts
@@ -5,8 +5,9 @@
 // <https://github.com/solana-labs/solana-web3.js/issues/1828>
 
 import { resolveAccount } from '../resolvers/account';
+import { AstConfig } from './ast';
 
-export const instructionTypeDefs = /* GraphQL */ `
+const instructionTypeDefs = /* GraphQL */ `
     # Transaction instruction interface
     interface TransactionInstruction {
         programId: Address
@@ -873,718 +874,736 @@ export const instructionTypeDefs = /* GraphQL */ `
     }
 `;
 
-export const instructionResolvers = {
-    TransactionInstruction: {
-        __resolveType(instruction: { programName: string; instructionType: string }) {
-            if (instruction.programName) {
-                if (instruction.programName === 'address-lookup-table') {
-                    if (instruction.instructionType === 'createLookupTable') {
-                        return 'CreateLookupTableInstruction';
+function instructionResolvers(resolveCustomInstructionTypeExtension?: (obj: unknown) => string) {
+    // TODO: This may not be the best default setup.
+    const resolveCustomInstructionType =
+        resolveCustomInstructionTypeExtension ?? (_instruction => 'GenericInstruction');
+    return {
+        TransactionInstruction: {
+            __resolveType(instruction: { programName: string; instructionType: string }) {
+                if (instruction.programName) {
+                    if (instruction.programName === 'address-lookup-table') {
+                        if (instruction.instructionType === 'createLookupTable') {
+                            return 'CreateLookupTableInstruction';
+                        }
+                        if (instruction.instructionType === 'freezeLookupTable') {
+                            return 'FreezeLookupTableInstruction';
+                        }
+                        if (instruction.instructionType === 'extendLookupTable') {
+                            return 'ExtendLookupTableInstruction';
+                        }
+                        if (instruction.instructionType === 'deactivateLookupTable') {
+                            return 'DeactivateLookupTableInstruction';
+                        }
+                        if (instruction.instructionType === 'closeLookupTable') {
+                            return 'CloseLookupTableInstruction';
+                        }
                     }
-                    if (instruction.instructionType === 'freezeLookupTable') {
-                        return 'FreezeLookupTableInstruction';
+                    if (instruction.programName === 'bpf-loader') {
+                        if (instruction.instructionType === 'write') {
+                            return 'BpfLoaderWriteInstruction';
+                        }
+                        if (instruction.instructionType === 'finalize') {
+                            return 'BpfLoaderFinalizeInstruction';
+                        }
                     }
-                    if (instruction.instructionType === 'extendLookupTable') {
-                        return 'ExtendLookupTableInstruction';
+                    if (instruction.programName === 'bpf-upgradeable-loader') {
+                        if (instruction.instructionType === 'initializeBuffer') {
+                            return 'BpfUpgradeableLoaderInitializeBufferInstruction';
+                        }
+                        if (instruction.instructionType === 'write') {
+                            return 'BpfUpgradeableLoaderWriteInstruction';
+                        }
+                        if (instruction.instructionType === 'deployWithMaxDataLen') {
+                            return 'BpfUpgradeableLoaderDeployWithMaxDataLenInstruction';
+                        }
+                        if (instruction.instructionType === 'upgrade') {
+                            return 'BpfUpgradeableLoaderUpgradeInstruction';
+                        }
+                        if (instruction.instructionType === 'setAuthority') {
+                            return 'BpfUpgradeableLoaderSetAuthorityInstruction';
+                        }
+                        if (instruction.instructionType === 'setAuthorityChecked') {
+                            return 'BpfUpgradeableLoaderSetAuthorityCheckedInstruction';
+                        }
+                        if (instruction.instructionType === 'close') {
+                            return 'BpfUpgradeableLoaderCloseInstruction';
+                        }
+                        if (instruction.instructionType === 'extendProgram') {
+                            return 'BpfUpgradeableLoaderExtendProgramInstruction';
+                        }
                     }
-                    if (instruction.instructionType === 'deactivateLookupTable') {
-                        return 'DeactivateLookupTableInstruction';
+                    if (instruction.programName === 'spl-associated-token-account') {
+                        if (instruction.instructionType === 'create') {
+                            return 'SplAssociatedTokenCreateInstruction';
+                        }
+                        if (instruction.instructionType === 'createIdempotent') {
+                            return 'SplAssociatedTokenCreateIdempotentInstruction';
+                        }
+                        if (instruction.instructionType === 'recoverNested') {
+                            return 'SplAssociatedTokenRecoverNestedInstruction';
+                        }
                     }
-                    if (instruction.instructionType === 'closeLookupTable') {
-                        return 'CloseLookupTableInstruction';
+                    if (instruction.programName === 'spl-memo') {
+                        return 'SplMemoInstruction';
                     }
+                    if (instruction.programName === 'spl-token') {
+                        if (instruction.instructionType === 'initializeMint') {
+                            return 'SplTokenInitializeMintInstruction';
+                        }
+                        if (instruction.instructionType === 'initializeMint2') {
+                            return 'SplTokenInitializeMint2Instruction';
+                        }
+                        if (instruction.instructionType === 'initializeAccount') {
+                            return 'SplTokenInitializeAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'initializeAccount2') {
+                            return 'SplTokenInitializeAccount2Instruction';
+                        }
+                        if (instruction.instructionType === 'initializeAccount3') {
+                            return 'SplTokenInitializeAccount3Instruction';
+                        }
+                        if (instruction.instructionType === 'initializeMultisig') {
+                            return 'SplTokenInitializeMultisigInstruction';
+                        }
+                        if (instruction.instructionType === 'initializeMultisig2') {
+                            return 'SplTokenInitializeMultisig2Instruction';
+                        }
+                        if (instruction.instructionType === 'transfer') {
+                            return 'SplTokenTransferInstruction';
+                        }
+                        if (instruction.instructionType === 'approve') {
+                            return 'SplTokenApproveInstruction';
+                        }
+                        if (instruction.instructionType === 'revoke') {
+                            return 'SplTokenRevokeInstruction';
+                        }
+                        if (instruction.instructionType === 'setAuthority') {
+                            return 'SplTokenSetAuthorityInstruction';
+                        }
+                        if (instruction.instructionType === 'mintTo') {
+                            return 'SplTokenMintToInstruction';
+                        }
+                        if (instruction.instructionType === 'burn') {
+                            return 'SplTokenBurnInstruction';
+                        }
+                        if (instruction.instructionType === 'closeAccount') {
+                            return 'SplTokenCloseAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'freezeAccount') {
+                            return 'SplTokenFreezeAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'thawAccount') {
+                            return 'SplTokenThawAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'transferChecked') {
+                            return 'SplTokenTransferCheckedInstruction';
+                        }
+                        if (instruction.instructionType === 'approveChecked') {
+                            return 'SplTokenApproveCheckedInstruction';
+                        }
+                        if (instruction.instructionType === 'mintToChecked') {
+                            return 'SplTokenMintToCheckedInstruction';
+                        }
+                        if (instruction.instructionType === 'burnChecked') {
+                            return 'SplTokenBurnCheckedInstruction';
+                        }
+                        if (instruction.instructionType === 'syncNative') {
+                            return 'SplTokenSyncNativeInstruction';
+                        }
+                        if (instruction.instructionType === 'getAccountDataSize') {
+                            return 'SplTokenGetAccountDataSizeInstruction';
+                        }
+                        if (instruction.instructionType === 'initializeImmutableOwner') {
+                            return 'SplTokenInitializeImmutableOwnerInstruction';
+                        }
+                        if (instruction.instructionType === 'amountToUiAmount') {
+                            return 'SplTokenAmountToUiAmountInstruction';
+                        }
+                        if (instruction.instructionType === 'uiAmountToAmount') {
+                            return 'SplTokenUiAmountToAmountInstruction';
+                        }
+                        if (instruction.instructionType === 'initializeMintCloseAuthority') {
+                            return 'SplTokenInitializeMintCloseAuthorityInstruction';
+                        }
+                    }
+                    if (instruction.programName === 'stake') {
+                        if (instruction.instructionType === 'initialize') {
+                            return 'StakeInitializeInstruction';
+                        }
+                        if (instruction.instructionType === 'authorize') {
+                            return 'StakeAuthorizeInstruction';
+                        }
+                        if (instruction.instructionType === 'delegate') {
+                            return 'StakeDelegateStakeInstruction';
+                        }
+                        if (instruction.instructionType === 'split') {
+                            return 'StakeSplitInstruction';
+                        }
+                        if (instruction.instructionType === 'withdraw') {
+                            return 'StakeWithdrawInstruction';
+                        }
+                        if (instruction.instructionType === 'deactivate') {
+                            return 'StakeDeactivateInstruction';
+                        }
+                        if (instruction.instructionType === 'setLockup') {
+                            return 'StakeSetLockupInstruction';
+                        }
+                        if (instruction.instructionType === 'merge') {
+                            return 'StakeMergeInstruction';
+                        }
+                        if (instruction.instructionType === 'authorizeWithSeed') {
+                            return 'StakeAuthorizeWithSeedInstruction';
+                        }
+                        if (instruction.instructionType === 'initializeChecked') {
+                            return 'StakeInitializeCheckedInstruction';
+                        }
+                        if (instruction.instructionType === 'authorizeChecked') {
+                            return 'StakeAuthorizeCheckedInstruction';
+                        }
+                        if (instruction.instructionType === 'authorizeCheckedWithSeed') {
+                            return 'StakeAuthorizeCheckedWithSeedInstruction';
+                        }
+                        if (instruction.instructionType === 'setLockupChecked') {
+                            return 'StakeSetLockupCheckedInstruction';
+                        }
+                        if (instruction.instructionType === 'deactivateDelinquent') {
+                            return 'StakeDeactivateDelinquentInstruction';
+                        }
+                        if (instruction.instructionType === 'redelegate') {
+                            return 'StakeRedelegateInstruction';
+                        }
+                    }
+                    if (instruction.programName === 'system') {
+                        if (instruction.instructionType === 'createAccount') {
+                            return 'CreateAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'assign') {
+                            return 'AssignInstruction';
+                        }
+                        if (instruction.instructionType === 'transfer') {
+                            return 'TransferInstruction';
+                        }
+                        if (instruction.instructionType === 'createAccountWithSeed') {
+                            return 'CreateAccountWithSeedInstruction';
+                        }
+                        if (instruction.instructionType === 'advanceNonceAccount') {
+                            return 'AdvanceNonceAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'withdrawNonceAccount') {
+                            return 'WithdrawNonceAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'initializeNonceAccount') {
+                            return 'InitializeNonceAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'authorizeNonceAccount') {
+                            return 'AuthorizeNonceAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'upgradeNonceAccount') {
+                            return 'UpgradeNonceAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'allocate') {
+                            return 'AllocateInstruction';
+                        }
+                        if (instruction.instructionType === 'allocateWithSeed') {
+                            return 'AllocateWithSeedInstruction';
+                        }
+                        if (instruction.instructionType === 'assignWithSeed') {
+                            return 'AssignWithSeedInstruction';
+                        }
+                        if (instruction.instructionType === 'transferWithSeed') {
+                            return 'TransferWithSeedInstruction';
+                        }
+                    }
+                    if (instruction.programName === 'vote') {
+                        if (instruction.instructionType === 'initialize') {
+                            return 'VoteInitializeAccountInstruction';
+                        }
+                        if (instruction.instructionType === 'authorize') {
+                            return 'VoteAuthorizeInstruction';
+                        }
+                        if (instruction.instructionType === 'authorizeWithSeed') {
+                            return 'VoteAuthorizeWithSeedInstruction';
+                        }
+                        if (instruction.instructionType === 'authorizeCheckedWithSeed') {
+                            return 'VoteAuthorizeCheckedWithSeedInstruction';
+                        }
+                        if (instruction.instructionType === 'vote') {
+                            return 'VoteVoteInstruction';
+                        }
+                        if (instruction.instructionType === 'updatevotestate') {
+                            return 'VoteUpdateVoteStateInstruction';
+                        }
+                        if (instruction.instructionType === 'updatevotestateswitch') {
+                            return 'VoteUpdateVoteStateSwitchInstruction';
+                        }
+                        if (instruction.instructionType === 'compactupdatevotestate') {
+                            return 'VoteCompactUpdateVoteStateInstruction';
+                        }
+                        if (instruction.instructionType === 'compactupdatevotestateswitch') {
+                            return 'VoteCompactUpdateVoteStateSwitchInstruction';
+                        }
+                        if (instruction.instructionType === 'withdraw') {
+                            return 'VoteWithdrawInstruction';
+                        }
+                        if (instruction.instructionType === 'updateValidatorIdentity') {
+                            return 'VoteUpdateValidatorIdentityInstruction';
+                        }
+                        if (instruction.instructionType === 'updateCommission') {
+                            return 'VoteUpdateCommissionInstruction';
+                        }
+                        if (instruction.instructionType === 'voteSwitch') {
+                            return 'VoteVoteSwitchInstruction';
+                        }
+                        if (instruction.instructionType === 'authorizeChecked') {
+                            return 'VoteAuthorizeCheckedInstruction';
+                        }
+                    }
+                    return resolveCustomInstructionType(instruction);
                 }
-                if (instruction.programName === 'bpf-loader') {
-                    if (instruction.instructionType === 'write') {
-                        return 'BpfLoaderWriteInstruction';
-                    }
-                    if (instruction.instructionType === 'finalize') {
-                        return 'BpfLoaderFinalizeInstruction';
-                    }
-                }
-                if (instruction.programName === 'bpf-upgradeable-loader') {
-                    if (instruction.instructionType === 'initializeBuffer') {
-                        return 'BpfUpgradeableLoaderInitializeBufferInstruction';
-                    }
-                    if (instruction.instructionType === 'write') {
-                        return 'BpfUpgradeableLoaderWriteInstruction';
-                    }
-                    if (instruction.instructionType === 'deployWithMaxDataLen') {
-                        return 'BpfUpgradeableLoaderDeployWithMaxDataLenInstruction';
-                    }
-                    if (instruction.instructionType === 'upgrade') {
-                        return 'BpfUpgradeableLoaderUpgradeInstruction';
-                    }
-                    if (instruction.instructionType === 'setAuthority') {
-                        return 'BpfUpgradeableLoaderSetAuthorityInstruction';
-                    }
-                    if (instruction.instructionType === 'setAuthorityChecked') {
-                        return 'BpfUpgradeableLoaderSetAuthorityCheckedInstruction';
-                    }
-                    if (instruction.instructionType === 'close') {
-                        return 'BpfUpgradeableLoaderCloseInstruction';
-                    }
-                    if (instruction.instructionType === 'extendProgram') {
-                        return 'BpfUpgradeableLoaderExtendProgramInstruction';
-                    }
-                }
-                if (instruction.programName === 'spl-associated-token-account') {
-                    if (instruction.instructionType === 'create') {
-                        return 'SplAssociatedTokenCreateInstruction';
-                    }
-                    if (instruction.instructionType === 'createIdempotent') {
-                        return 'SplAssociatedTokenCreateIdempotentInstruction';
-                    }
-                    if (instruction.instructionType === 'recoverNested') {
-                        return 'SplAssociatedTokenRecoverNestedInstruction';
-                    }
-                }
-                if (instruction.programName === 'spl-memo') {
-                    return 'SplMemoInstruction';
-                }
-                if (instruction.programName === 'spl-token') {
-                    if (instruction.instructionType === 'initializeMint') {
-                        return 'SplTokenInitializeMintInstruction';
-                    }
-                    if (instruction.instructionType === 'initializeMint2') {
-                        return 'SplTokenInitializeMint2Instruction';
-                    }
-                    if (instruction.instructionType === 'initializeAccount') {
-                        return 'SplTokenInitializeAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'initializeAccount2') {
-                        return 'SplTokenInitializeAccount2Instruction';
-                    }
-                    if (instruction.instructionType === 'initializeAccount3') {
-                        return 'SplTokenInitializeAccount3Instruction';
-                    }
-                    if (instruction.instructionType === 'initializeMultisig') {
-                        return 'SplTokenInitializeMultisigInstruction';
-                    }
-                    if (instruction.instructionType === 'initializeMultisig2') {
-                        return 'SplTokenInitializeMultisig2Instruction';
-                    }
-                    if (instruction.instructionType === 'transfer') {
-                        return 'SplTokenTransferInstruction';
-                    }
-                    if (instruction.instructionType === 'approve') {
-                        return 'SplTokenApproveInstruction';
-                    }
-                    if (instruction.instructionType === 'revoke') {
-                        return 'SplTokenRevokeInstruction';
-                    }
-                    if (instruction.instructionType === 'setAuthority') {
-                        return 'SplTokenSetAuthorityInstruction';
-                    }
-                    if (instruction.instructionType === 'mintTo') {
-                        return 'SplTokenMintToInstruction';
-                    }
-                    if (instruction.instructionType === 'burn') {
-                        return 'SplTokenBurnInstruction';
-                    }
-                    if (instruction.instructionType === 'closeAccount') {
-                        return 'SplTokenCloseAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'freezeAccount') {
-                        return 'SplTokenFreezeAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'thawAccount') {
-                        return 'SplTokenThawAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'transferChecked') {
-                        return 'SplTokenTransferCheckedInstruction';
-                    }
-                    if (instruction.instructionType === 'approveChecked') {
-                        return 'SplTokenApproveCheckedInstruction';
-                    }
-                    if (instruction.instructionType === 'mintToChecked') {
-                        return 'SplTokenMintToCheckedInstruction';
-                    }
-                    if (instruction.instructionType === 'burnChecked') {
-                        return 'SplTokenBurnCheckedInstruction';
-                    }
-                    if (instruction.instructionType === 'syncNative') {
-                        return 'SplTokenSyncNativeInstruction';
-                    }
-                    if (instruction.instructionType === 'getAccountDataSize') {
-                        return 'SplTokenGetAccountDataSizeInstruction';
-                    }
-                    if (instruction.instructionType === 'initializeImmutableOwner') {
-                        return 'SplTokenInitializeImmutableOwnerInstruction';
-                    }
-                    if (instruction.instructionType === 'amountToUiAmount') {
-                        return 'SplTokenAmountToUiAmountInstruction';
-                    }
-                    if (instruction.instructionType === 'uiAmountToAmount') {
-                        return 'SplTokenUiAmountToAmountInstruction';
-                    }
-                    if (instruction.instructionType === 'initializeMintCloseAuthority') {
-                        return 'SplTokenInitializeMintCloseAuthorityInstruction';
-                    }
-                }
-                if (instruction.programName === 'stake') {
-                    if (instruction.instructionType === 'initialize') {
-                        return 'StakeInitializeInstruction';
-                    }
-                    if (instruction.instructionType === 'authorize') {
-                        return 'StakeAuthorizeInstruction';
-                    }
-                    if (instruction.instructionType === 'delegate') {
-                        return 'StakeDelegateStakeInstruction';
-                    }
-                    if (instruction.instructionType === 'split') {
-                        return 'StakeSplitInstruction';
-                    }
-                    if (instruction.instructionType === 'withdraw') {
-                        return 'StakeWithdrawInstruction';
-                    }
-                    if (instruction.instructionType === 'deactivate') {
-                        return 'StakeDeactivateInstruction';
-                    }
-                    if (instruction.instructionType === 'setLockup') {
-                        return 'StakeSetLockupInstruction';
-                    }
-                    if (instruction.instructionType === 'merge') {
-                        return 'StakeMergeInstruction';
-                    }
-                    if (instruction.instructionType === 'authorizeWithSeed') {
-                        return 'StakeAuthorizeWithSeedInstruction';
-                    }
-                    if (instruction.instructionType === 'initializeChecked') {
-                        return 'StakeInitializeCheckedInstruction';
-                    }
-                    if (instruction.instructionType === 'authorizeChecked') {
-                        return 'StakeAuthorizeCheckedInstruction';
-                    }
-                    if (instruction.instructionType === 'authorizeCheckedWithSeed') {
-                        return 'StakeAuthorizeCheckedWithSeedInstruction';
-                    }
-                    if (instruction.instructionType === 'setLockupChecked') {
-                        return 'StakeSetLockupCheckedInstruction';
-                    }
-                    if (instruction.instructionType === 'deactivateDelinquent') {
-                        return 'StakeDeactivateDelinquentInstruction';
-                    }
-                    if (instruction.instructionType === 'redelegate') {
-                        return 'StakeRedelegateInstruction';
-                    }
-                }
-                if (instruction.programName === 'system') {
-                    if (instruction.instructionType === 'createAccount') {
-                        return 'CreateAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'assign') {
-                        return 'AssignInstruction';
-                    }
-                    if (instruction.instructionType === 'transfer') {
-                        return 'TransferInstruction';
-                    }
-                    if (instruction.instructionType === 'createAccountWithSeed') {
-                        return 'CreateAccountWithSeedInstruction';
-                    }
-                    if (instruction.instructionType === 'advanceNonceAccount') {
-                        return 'AdvanceNonceAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'withdrawNonceAccount') {
-                        return 'WithdrawNonceAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'initializeNonceAccount') {
-                        return 'InitializeNonceAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'authorizeNonceAccount') {
-                        return 'AuthorizeNonceAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'upgradeNonceAccount') {
-                        return 'UpgradeNonceAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'allocate') {
-                        return 'AllocateInstruction';
-                    }
-                    if (instruction.instructionType === 'allocateWithSeed') {
-                        return 'AllocateWithSeedInstruction';
-                    }
-                    if (instruction.instructionType === 'assignWithSeed') {
-                        return 'AssignWithSeedInstruction';
-                    }
-                    if (instruction.instructionType === 'transferWithSeed') {
-                        return 'TransferWithSeedInstruction';
-                    }
-                }
-                if (instruction.programName === 'vote') {
-                    if (instruction.instructionType === 'initialize') {
-                        return 'VoteInitializeAccountInstruction';
-                    }
-                    if (instruction.instructionType === 'authorize') {
-                        return 'VoteAuthorizeInstruction';
-                    }
-                    if (instruction.instructionType === 'authorizeWithSeed') {
-                        return 'VoteAuthorizeWithSeedInstruction';
-                    }
-                    if (instruction.instructionType === 'authorizeCheckedWithSeed') {
-                        return 'VoteAuthorizeCheckedWithSeedInstruction';
-                    }
-                    if (instruction.instructionType === 'vote') {
-                        return 'VoteVoteInstruction';
-                    }
-                    if (instruction.instructionType === 'updatevotestate') {
-                        return 'VoteUpdateVoteStateInstruction';
-                    }
-                    if (instruction.instructionType === 'updatevotestateswitch') {
-                        return 'VoteUpdateVoteStateSwitchInstruction';
-                    }
-                    if (instruction.instructionType === 'compactupdatevotestate') {
-                        return 'VoteCompactUpdateVoteStateInstruction';
-                    }
-                    if (instruction.instructionType === 'compactupdatevotestateswitch') {
-                        return 'VoteCompactUpdateVoteStateSwitchInstruction';
-                    }
-                    if (instruction.instructionType === 'withdraw') {
-                        return 'VoteWithdrawInstruction';
-                    }
-                    if (instruction.instructionType === 'updateValidatorIdentity') {
-                        return 'VoteUpdateValidatorIdentityInstruction';
-                    }
-                    if (instruction.instructionType === 'updateCommission') {
-                        return 'VoteUpdateCommissionInstruction';
-                    }
-                    if (instruction.instructionType === 'voteSwitch') {
-                        return 'VoteVoteSwitchInstruction';
-                    }
-                    if (instruction.instructionType === 'authorizeChecked') {
-                        return 'VoteAuthorizeCheckedInstruction';
-                    }
-                }
-            }
-            return 'GenericInstruction';
+                return 'GenericInstruction';
+            },
         },
-    },
-    CreateLookupTableInstruction: {
-        lookupTableAccount: resolveAccount('lookupTableAccount'),
-        lookupTableAuthority: resolveAccount('lookupTableAuthority'),
-        payerAccount: resolveAccount('payerAccount'),
-        systemProgram: resolveAccount('systemProgram'),
-    },
-    ExtendLookupTableInstruction: {
-        lookupTableAccount: resolveAccount('lookupTableAccount'),
-        lookupTableAuthority: resolveAccount('lookupTableAuthority'),
-        payerAccount: resolveAccount('payerAccount'),
-        systemProgram: resolveAccount('systemProgram'),
-    },
-    FreezeLookupTableInstruction: {
-        lookupTableAccount: resolveAccount('lookupTableAccount'),
-        lookupTableAuthority: resolveAccount('lookupTableAuthority'),
-    },
-    DeactivateLookupTableInstruction: {
-        lookupTableAccount: resolveAccount('lookupTableAccount'),
-        lookupTableAuthority: resolveAccount('lookupTableAuthority'),
-    },
-    CloseLookupTableInstruction: {
-        lookupTableAccount: resolveAccount('lookupTableAccount'),
-        lookupTableAuthority: resolveAccount('lookupTableAuthority'),
-        recipient: resolveAccount('recipient'),
-    },
-    BpfLoaderWriteInstruction: {
-        account: resolveAccount('account'),
-    },
-    BpfLoaderFinalizeInstruction: {
-        account: resolveAccount('account'),
-    },
-    BpfUpgradeableLoaderInitializeBufferInstruction: {
-        account: resolveAccount('account'),
-    },
-    BpfUpgradeableLoaderWriteInstruction: {
-        account: resolveAccount('account'),
-        authority: resolveAccount('authority'),
-    },
-    BpfUpgradeableLoaderDeployWithMaxDataLenInstruction: {
-        authority: resolveAccount('authority'),
-        bufferAccount: resolveAccount('bufferAccount'),
-        payerAccount: resolveAccount('payerAccount'),
-        programAccount: resolveAccount('programAccount'),
-        programDataAccount: resolveAccount('programDataAccount'),
-    },
-    BpfUpgradeableLoaderUpgradeInstruction: {
-        authority: resolveAccount('authority'),
-        bufferAccount: resolveAccount('bufferAccount'),
-        programAccount: resolveAccount('programAccount'),
-        programDataAccount: resolveAccount('programDataAccount'),
-    },
-    BpfUpgradeableLoaderSetAuthorityInstruction: {
-        account: resolveAccount('account'),
-        authority: resolveAccount('authority'),
-        newAuthority: resolveAccount('newAuthority'),
-    },
-    BpfUpgradeableLoaderSetAuthorityCheckedInstruction: {
-        account: resolveAccount('account'),
-        authority: resolveAccount('authority'),
-        newAuthority: resolveAccount('newAuthority'),
-    },
-    BpfUpgradeableLoaderCloseInstruction: {
-        account: resolveAccount('account'),
-        authority: resolveAccount('authority'),
-        programAccount: resolveAccount('programAccount'),
-        recipient: resolveAccount('recipient'),
-    },
-    BpfUpgradeableLoaderExtendProgramInstruction: {
-        payerAccount: resolveAccount('payerAccount'),
-        programAccount: resolveAccount('programAccount'),
-        programDataAccount: resolveAccount('programDataAccount'),
-        systemProgram: resolveAccount('systemProgram'),
-    },
-    SplAssociatedTokenCreateInstruction: {
-        account: resolveAccount('account'),
-        mint: resolveAccount('mint'),
-        source: resolveAccount('source'),
-        systemProgram: resolveAccount('systemProgram'),
-        tokenProgram: resolveAccount('tokenProgram'),
-        wallet: resolveAccount('wallet'),
-    },
-    SplAssociatedTokenCreateIdempotentInstruction: {
-        account: resolveAccount('account'),
-        mint: resolveAccount('mint'),
-        source: resolveAccount('source'),
-        systemProgram: resolveAccount('systemProgram'),
-        tokenProgram: resolveAccount('tokenProgram'),
-        wallet: resolveAccount('wallet'),
-    },
-    SplAssociatedTokenRecoverNestedInstruction: {
-        destination: resolveAccount('destination'),
-        nestedMint: resolveAccount('nestedMint'),
-        nestedOwner: resolveAccount('nestedOwner'),
-        nestedSource: resolveAccount('nestedSource'),
-        ownerMint: resolveAccount('ownerMint'),
-        tokenProgram: resolveAccount('tokenProgram'),
-        wallet: resolveAccount('wallet'),
-    },
-    SplTokenInitializeMintInstruction: {
-        freezeAuthority: resolveAccount('freezeAuthority'),
-        mint: resolveAccount('mint'),
-        mintAuthority: resolveAccount('mintAuthority'),
-    },
-    SplTokenInitializeMint2Instruction: {
-        freezeAuthority: resolveAccount('freezeAuthority'),
-        mint: resolveAccount('mint'),
-        mintAuthority: resolveAccount('mintAuthority'),
-    },
-    SplTokenInitializeAccountInstruction: {
-        account: resolveAccount('account'),
-        mint: resolveAccount('mint'),
-        owner: resolveAccount('owner'),
-    },
-    SplTokenInitializeAccount2Instruction: {
-        account: resolveAccount('account'),
-        mint: resolveAccount('mint'),
-        owner: resolveAccount('owner'),
-    },
-    SplTokenInitializeAccount3Instruction: {
-        account: resolveAccount('account'),
-        mint: resolveAccount('mint'),
-        owner: resolveAccount('owner'),
-    },
-    SplTokenInitializeMultisigInstruction: {
-        multisig: resolveAccount('multisig'),
-    },
-    SplTokenInitializeMultisig2Instruction: {
-        multisig: resolveAccount('multisig'),
-    },
-    SplTokenTransferInstruction: {
-        authority: resolveAccount('authority'),
-        destination: resolveAccount('destination'),
-        multisigAuthority: resolveAccount('multisigAuthority'),
-        source: resolveAccount('source'),
-    },
-    SplTokenApproveInstruction: {
-        delegate: resolveAccount('delegate'),
-        multisigOwner: resolveAccount('multisigOwner'),
-        owner: resolveAccount('owner'),
-        source: resolveAccount('source'),
-    },
-    SplTokenRevokeInstruction: {
-        multisigOwner: resolveAccount('multisigOwner'),
-        owner: resolveAccount('owner'),
-        source: resolveAccount('source'),
-    },
-    SplTokenSetAuthorityInstruction: {
-        authority: resolveAccount('authority'),
-        multisigAuthority: resolveAccount('multisigAuthority'),
-        newAuthority: resolveAccount('newAuthority'),
-    },
-    SplTokenMintToInstruction: {
-        account: resolveAccount('account'),
-        authority: resolveAccount('authority'),
-        mint: resolveAccount('mint'),
-        mintAuthority: resolveAccount('mintAuthority'),
-        multisigMintAuthority: resolveAccount('multisigMintAuthority'),
-    },
-    SplTokenBurnInstruction: {
-        account: resolveAccount('account'),
-        authority: resolveAccount('authority'),
-        mint: resolveAccount('mint'),
-        multisigAuthority: resolveAccount('multisigAuthority'),
-    },
-    SplTokenCloseAccountInstruction: {
-        account: resolveAccount('account'),
-        destination: resolveAccount('destination'),
-        multisigOwner: resolveAccount('multisigOwner'),
-        owner: resolveAccount('owner'),
-    },
-    SplTokenFreezeAccountInstruction: {
-        account: resolveAccount('account'),
-        freezeAuthority: resolveAccount('freezeAuthority'),
-        mint: resolveAccount('mint'),
-        multisigFreezeAuthority: resolveAccount('multisigFreezeAuthority'),
-    },
-    SplTokenThawAccountInstruction: {
-        account: resolveAccount('account'),
-        freezeAuthority: resolveAccount('freezeAuthority'),
-        mint: resolveAccount('mint'),
-        multisigFreezeAuthority: resolveAccount('multisigFreezeAuthority'),
-    },
-    SplTokenTransferCheckedInstruction: {
-        authority: resolveAccount('authority'),
-        destination: resolveAccount('destination'),
-        mint: resolveAccount('mint'),
-        multisigAuthority: resolveAccount('multisigAuthority'),
-        source: resolveAccount('source'),
-    },
-    SplTokenApproveCheckedInstruction: {
-        delegate: resolveAccount('delegate'),
-        mint: resolveAccount('mint'),
-        multisigOwner: resolveAccount('multisigOwner'),
-        owner: resolveAccount('owner'),
-        source: resolveAccount('source'),
-    },
-    SplTokenMintToCheckedInstruction: {
-        account: resolveAccount('account'),
-        authority: resolveAccount('authority'),
-        mint: resolveAccount('mint'),
-        mintAuthority: resolveAccount('mintAuthority'),
-        multisigMintAuthority: resolveAccount('multisigMintAuthority'),
-    },
-    SplTokenBurnCheckedInstruction: {
-        account: resolveAccount('account'),
-        authority: resolveAccount('authority'),
-        mint: resolveAccount('mint'),
-        multisigAuthority: resolveAccount('multisigAuthority'),
-    },
-    SplTokenSyncNativeInstruction: {
-        account: resolveAccount('account'),
-    },
-    SplTokenGetAccountDataSizeInstruction: {
-        mint: resolveAccount('mint'),
-    },
-    SplTokenAmountToUiAmountInstruction: {
-        mint: resolveAccount('mint'),
-    },
-    SplTokenUiAmountToAmountInstruction: {
-        mint: resolveAccount('mint'),
-    },
-    SplTokenInitializeMintCloseAuthorityInstruction: {
-        mint: resolveAccount('mint'),
-        newAuthority: resolveAccount('newAuthority'),
-    },
-    Lockup: {
-        custodian: resolveAccount('custodian'),
-    },
-    StakeInitializeInstructionDataAuthorized: {
-        staker: resolveAccount('staker'),
-        withdrawer: resolveAccount('withdrawer'),
-    },
-    StakeInitializeInstruction: {
-        stakeAccount: resolveAccount('stakeAccount'),
-    },
-    StakeAuthorizeInstruction: {
-        authority: resolveAccount('authority'),
-        custodian: resolveAccount('custodian'),
-        newAuthority: resolveAccount('newAuthority'),
-        stakeAccount: resolveAccount('stakeAccount'),
-    },
-    StakeDelegateStakeInstruction: {
-        stakeAccount: resolveAccount('stakeAccount'),
-        stakeAuthority: resolveAccount('stakeAuthority'),
-        stakeConfigAccount: resolveAccount('stakeConfigAccount'),
-        voteAccount: resolveAccount('voteAccount'),
-    },
-    StakeSplitInstruction: {
-        newSplitAccount: resolveAccount('newSplitAccount'),
-        stakeAccount: resolveAccount('stakeAccount'),
-        stakeAuthority: resolveAccount('stakeAuthority'),
-    },
-    StakeWithdrawInstruction: {
-        destination: resolveAccount('destination'),
-        stakeAccount: resolveAccount('stakeAccount'),
-        withdrawAuthority: resolveAccount('withdrawAuthority'),
-    },
-    StakeDeactivateInstruction: {
-        stakeAccount: resolveAccount('stakeAccount'),
-        stakeAuthority: resolveAccount('stakeAuthority'),
-    },
-    StakeSetLockupInstruction: {
-        custodian: resolveAccount('custodian'),
-        stakeAccount: resolveAccount('stakeAccount'),
-    },
-    StakeMergeInstruction: {
-        destination: resolveAccount('destination'),
-        source: resolveAccount('source'),
-        stakeAuthority: resolveAccount('stakeAuthority'),
-    },
-    StakeAuthorizeWithSeedInstruction: {
-        authorityBase: resolveAccount('authorityBase'),
-        authorityOwner: resolveAccount('authorityOwner'),
-        custodian: resolveAccount('custodian'),
-        newAuthorized: resolveAccount('newAuthorized'),
-        stakeAccount: resolveAccount('stakeAccount'),
-    },
-    StakeInitializeCheckedInstructionDataAuthorized: {
-        staker: resolveAccount('staker'),
-        withdrawer: resolveAccount('withdrawer'),
-    },
-    StakeAuthorizeCheckedInstruction: {
-        authority: resolveAccount('authority'),
-        custodian: resolveAccount('custodian'),
-        newAuthority: resolveAccount('newAuthority'),
-        stakeAccount: resolveAccount('stakeAccount'),
-    },
-    StakeAuthorizeCheckedWithSeedInstruction: {
-        authorityBase: resolveAccount('authorityBase'),
-        authorityOwner: resolveAccount('authorityOwner'),
-        custodian: resolveAccount('custodian'),
-        newAuthorized: resolveAccount('newAuthorized'),
-        stakeAccount: resolveAccount('stakeAccount'),
-    },
-    StakeSetLockupCheckedInstruction: {
-        custodian: resolveAccount('custodian'),
-        stakeAccount: resolveAccount('stakeAccount'),
-    },
-    StakeDeactivateDelinquentInstruction: {
-        referenceVoteAccount: resolveAccount('referenceVoteAccount'),
-        stakeAccount: resolveAccount('stakeAccount'),
-        voteAccount: resolveAccount('voteAccount'),
-    },
-    StakeRedelegateInstruction: {
-        newStakeAccount: resolveAccount('newStakeAccount'),
-        stakeAccount: resolveAccount('stakeAccount'),
-        stakeAuthority: resolveAccount('stakeAuthority'),
-        stakeConfigAccount: resolveAccount('stakeConfigAccount'),
-        voteAccount: resolveAccount('voteAccount'),
-    },
-    CreateAccountInstruction: {
-        newAccount: resolveAccount('newAccount'),
-        owner: resolveAccount('owner'),
-        source: resolveAccount('source'),
-    },
-    AssignInstruction: {
-        account: resolveAccount('account'),
-        owner: resolveAccount('owner'),
-    },
-    TransferInstruction: {
-        destination: resolveAccount('destination'),
-        source: resolveAccount('source'),
-    },
-    CreateAccountWithSeedInstruction: {
-        base: resolveAccount('base'),
-        owner: resolveAccount('owner'),
-        seed: resolveAccount('seed'),
-    },
-    AdvanceNonceAccountInstruction: {
-        nonceAccount: resolveAccount('nonceAccount'),
-        nonceAuthority: resolveAccount('nonceAuthority'),
-    },
-    WithdrawNonceAccountInstruction: {
-        destination: resolveAccount('destination'),
-        nonceAccount: resolveAccount('nonceAccount'),
-        nonceAuthority: resolveAccount('nonceAuthority'),
-    },
-    InitializeNonceAccountInstruction: {
-        nonceAccount: resolveAccount('nonceAccount'),
-        nonceAuthority: resolveAccount('nonceAuthority'),
-    },
-    AuthorizeNonceAccountInstruction: {
-        newAuthorized: resolveAccount('newAuthorized'),
-        nonceAccount: resolveAccount('nonceAccount'),
-        nonceAuthority: resolveAccount('nonceAuthority'),
-    },
-    UpgradeNonceAccountInstruction: {
-        nonceAccount: resolveAccount('nonceAccount'),
-        nonceAuthority: resolveAccount('nonceAuthority'),
-    },
-    AllocateInstruction: {
-        account: resolveAccount('account'),
-    },
-    AllocateWithSeedInstruction: {
-        account: resolveAccount('account'),
-        owner: resolveAccount('owner'),
-    },
-    AssignWithSeedInstruction: {
-        account: resolveAccount('account'),
-        owner: resolveAccount('owner'),
-    },
-    TransferWithSeedInstruction: {
-        destination: resolveAccount('destination'),
-        source: resolveAccount('source'),
-        sourceOwner: resolveAccount('sourceOwner'),
-    },
-    VoteInitializeAccountInstruction: {
-        authorizedVoter: resolveAccount('authorizedVoter'),
-        authorizedWithdrawer: resolveAccount('authorizedWithdrawer'),
-        node: resolveAccount('node'),
-        voteAccount: resolveAccount('voteAccount'),
-    },
-    VoteAuthorizeInstruction: {
-        authority: resolveAccount('authority'),
-        newAuthority: resolveAccount('newAuthority'),
-        voteAccount: resolveAccount('voteAccount'),
-    },
-    VoteAuthorizeWithSeedInstruction: {
-        authorityOwner: resolveAccount('authorityOwner'),
-        newAuthority: resolveAccount('newAuthority'),
-        voteAccount: resolveAccount('voteAccount'),
-    },
-    VoteAuthorizeCheckedWithSeedInstruction: {
-        authorityOwner: resolveAccount('authorityOwner'),
-        newAuthority: resolveAccount('newAuthority'),
-        voteAccount: resolveAccount('voteAccount'),
-    },
-    VoteVoteInstruction: {
-        voteAccount: resolveAccount('voteAccount'),
-        voteAuthority: resolveAccount('voteAuthority'),
-    },
-    VoteUpdateVoteStateInstruction: {
-        voteAccount: resolveAccount('voteAccount'),
-        voteAuthority: resolveAccount('voteAuthority'),
-    },
-    VoteUpdateVoteStateSwitchInstruction: {
-        voteAccount: resolveAccount('voteAccount'),
-        voteAuthority: resolveAccount('voteAuthority'),
-    },
-    VoteCompactUpdateVoteStateInstruction: {
-        voteAccount: resolveAccount('voteAccount'),
-        voteAuthority: resolveAccount('voteAuthority'),
-    },
-    VoteCompactUpdateVoteStateSwitchInstruction: {
-        voteAccount: resolveAccount('voteAccount'),
-        voteAuthority: resolveAccount('voteAuthority'),
-    },
-    VoteWithdrawInstruction: {
-        voteAccount: resolveAccount('voteAccount'),
-        withdrawAuthority: resolveAccount('withdrawAuthority'),
-    },
-    VoteUpdateValidatorIdentityInstruction: {
-        newValidatorIdentity: resolveAccount('newValidatorIdentity'),
-        voteAccount: resolveAccount('voteAccount'),
-        withdrawAuthority: resolveAccount('withdrawAuthority'),
-    },
-    VoteUpdateCommissionInstruction: {
-        voteAccount: resolveAccount('voteAccount'),
-        withdrawAuthority: resolveAccount('withdrawAuthority'),
-    },
-    VoteVoteSwitchInstruction: {
-        voteAccount: resolveAccount('voteAccount'),
-        voteAuthority: resolveAccount('voteAuthority'),
-    },
-    VoteAuthorizeCheckedInstruction: {
-        authority: resolveAccount('authority'),
-        newAuthority: resolveAccount('newAuthority'),
-        voteAccount: resolveAccount('voteAccount'),
-    },
-};
+        CreateLookupTableInstruction: {
+            lookupTableAccount: resolveAccount('lookupTableAccount'),
+            lookupTableAuthority: resolveAccount('lookupTableAuthority'),
+            payerAccount: resolveAccount('payerAccount'),
+            systemProgram: resolveAccount('systemProgram'),
+        },
+        ExtendLookupTableInstruction: {
+            lookupTableAccount: resolveAccount('lookupTableAccount'),
+            lookupTableAuthority: resolveAccount('lookupTableAuthority'),
+            payerAccount: resolveAccount('payerAccount'),
+            systemProgram: resolveAccount('systemProgram'),
+        },
+        FreezeLookupTableInstruction: {
+            lookupTableAccount: resolveAccount('lookupTableAccount'),
+            lookupTableAuthority: resolveAccount('lookupTableAuthority'),
+        },
+        DeactivateLookupTableInstruction: {
+            lookupTableAccount: resolveAccount('lookupTableAccount'),
+            lookupTableAuthority: resolveAccount('lookupTableAuthority'),
+        },
+        CloseLookupTableInstruction: {
+            lookupTableAccount: resolveAccount('lookupTableAccount'),
+            lookupTableAuthority: resolveAccount('lookupTableAuthority'),
+            recipient: resolveAccount('recipient'),
+        },
+        BpfLoaderWriteInstruction: {
+            account: resolveAccount('account'),
+        },
+        BpfLoaderFinalizeInstruction: {
+            account: resolveAccount('account'),
+        },
+        BpfUpgradeableLoaderInitializeBufferInstruction: {
+            account: resolveAccount('account'),
+        },
+        BpfUpgradeableLoaderWriteInstruction: {
+            account: resolveAccount('account'),
+            authority: resolveAccount('authority'),
+        },
+        BpfUpgradeableLoaderDeployWithMaxDataLenInstruction: {
+            authority: resolveAccount('authority'),
+            bufferAccount: resolveAccount('bufferAccount'),
+            payerAccount: resolveAccount('payerAccount'),
+            programAccount: resolveAccount('programAccount'),
+            programDataAccount: resolveAccount('programDataAccount'),
+        },
+        BpfUpgradeableLoaderUpgradeInstruction: {
+            authority: resolveAccount('authority'),
+            bufferAccount: resolveAccount('bufferAccount'),
+            programAccount: resolveAccount('programAccount'),
+            programDataAccount: resolveAccount('programDataAccount'),
+        },
+        BpfUpgradeableLoaderSetAuthorityInstruction: {
+            account: resolveAccount('account'),
+            authority: resolveAccount('authority'),
+            newAuthority: resolveAccount('newAuthority'),
+        },
+        BpfUpgradeableLoaderSetAuthorityCheckedInstruction: {
+            account: resolveAccount('account'),
+            authority: resolveAccount('authority'),
+            newAuthority: resolveAccount('newAuthority'),
+        },
+        BpfUpgradeableLoaderCloseInstruction: {
+            account: resolveAccount('account'),
+            authority: resolveAccount('authority'),
+            programAccount: resolveAccount('programAccount'),
+            recipient: resolveAccount('recipient'),
+        },
+        BpfUpgradeableLoaderExtendProgramInstruction: {
+            payerAccount: resolveAccount('payerAccount'),
+            programAccount: resolveAccount('programAccount'),
+            programDataAccount: resolveAccount('programDataAccount'),
+            systemProgram: resolveAccount('systemProgram'),
+        },
+        SplAssociatedTokenCreateInstruction: {
+            account: resolveAccount('account'),
+            mint: resolveAccount('mint'),
+            source: resolveAccount('source'),
+            systemProgram: resolveAccount('systemProgram'),
+            tokenProgram: resolveAccount('tokenProgram'),
+            wallet: resolveAccount('wallet'),
+        },
+        SplAssociatedTokenCreateIdempotentInstruction: {
+            account: resolveAccount('account'),
+            mint: resolveAccount('mint'),
+            source: resolveAccount('source'),
+            systemProgram: resolveAccount('systemProgram'),
+            tokenProgram: resolveAccount('tokenProgram'),
+            wallet: resolveAccount('wallet'),
+        },
+        SplAssociatedTokenRecoverNestedInstruction: {
+            destination: resolveAccount('destination'),
+            nestedMint: resolveAccount('nestedMint'),
+            nestedOwner: resolveAccount('nestedOwner'),
+            nestedSource: resolveAccount('nestedSource'),
+            ownerMint: resolveAccount('ownerMint'),
+            tokenProgram: resolveAccount('tokenProgram'),
+            wallet: resolveAccount('wallet'),
+        },
+        SplTokenInitializeMintInstruction: {
+            freezeAuthority: resolveAccount('freezeAuthority'),
+            mint: resolveAccount('mint'),
+            mintAuthority: resolveAccount('mintAuthority'),
+        },
+        SplTokenInitializeMint2Instruction: {
+            freezeAuthority: resolveAccount('freezeAuthority'),
+            mint: resolveAccount('mint'),
+            mintAuthority: resolveAccount('mintAuthority'),
+        },
+        SplTokenInitializeAccountInstruction: {
+            account: resolveAccount('account'),
+            mint: resolveAccount('mint'),
+            owner: resolveAccount('owner'),
+        },
+        SplTokenInitializeAccount2Instruction: {
+            account: resolveAccount('account'),
+            mint: resolveAccount('mint'),
+            owner: resolveAccount('owner'),
+        },
+        SplTokenInitializeAccount3Instruction: {
+            account: resolveAccount('account'),
+            mint: resolveAccount('mint'),
+            owner: resolveAccount('owner'),
+        },
+        SplTokenInitializeMultisigInstruction: {
+            multisig: resolveAccount('multisig'),
+        },
+        SplTokenInitializeMultisig2Instruction: {
+            multisig: resolveAccount('multisig'),
+        },
+        SplTokenTransferInstruction: {
+            authority: resolveAccount('authority'),
+            destination: resolveAccount('destination'),
+            multisigAuthority: resolveAccount('multisigAuthority'),
+            source: resolveAccount('source'),
+        },
+        SplTokenApproveInstruction: {
+            delegate: resolveAccount('delegate'),
+            multisigOwner: resolveAccount('multisigOwner'),
+            owner: resolveAccount('owner'),
+            source: resolveAccount('source'),
+        },
+        SplTokenRevokeInstruction: {
+            multisigOwner: resolveAccount('multisigOwner'),
+            owner: resolveAccount('owner'),
+            source: resolveAccount('source'),
+        },
+        SplTokenSetAuthorityInstruction: {
+            authority: resolveAccount('authority'),
+            multisigAuthority: resolveAccount('multisigAuthority'),
+            newAuthority: resolveAccount('newAuthority'),
+        },
+        SplTokenMintToInstruction: {
+            account: resolveAccount('account'),
+            authority: resolveAccount('authority'),
+            mint: resolveAccount('mint'),
+            mintAuthority: resolveAccount('mintAuthority'),
+            multisigMintAuthority: resolveAccount('multisigMintAuthority'),
+        },
+        SplTokenBurnInstruction: {
+            account: resolveAccount('account'),
+            authority: resolveAccount('authority'),
+            mint: resolveAccount('mint'),
+            multisigAuthority: resolveAccount('multisigAuthority'),
+        },
+        SplTokenCloseAccountInstruction: {
+            account: resolveAccount('account'),
+            destination: resolveAccount('destination'),
+            multisigOwner: resolveAccount('multisigOwner'),
+            owner: resolveAccount('owner'),
+        },
+        SplTokenFreezeAccountInstruction: {
+            account: resolveAccount('account'),
+            freezeAuthority: resolveAccount('freezeAuthority'),
+            mint: resolveAccount('mint'),
+            multisigFreezeAuthority: resolveAccount('multisigFreezeAuthority'),
+        },
+        SplTokenThawAccountInstruction: {
+            account: resolveAccount('account'),
+            freezeAuthority: resolveAccount('freezeAuthority'),
+            mint: resolveAccount('mint'),
+            multisigFreezeAuthority: resolveAccount('multisigFreezeAuthority'),
+        },
+        SplTokenTransferCheckedInstruction: {
+            authority: resolveAccount('authority'),
+            destination: resolveAccount('destination'),
+            mint: resolveAccount('mint'),
+            multisigAuthority: resolveAccount('multisigAuthority'),
+            source: resolveAccount('source'),
+        },
+        SplTokenApproveCheckedInstruction: {
+            delegate: resolveAccount('delegate'),
+            mint: resolveAccount('mint'),
+            multisigOwner: resolveAccount('multisigOwner'),
+            owner: resolveAccount('owner'),
+            source: resolveAccount('source'),
+        },
+        SplTokenMintToCheckedInstruction: {
+            account: resolveAccount('account'),
+            authority: resolveAccount('authority'),
+            mint: resolveAccount('mint'),
+            mintAuthority: resolveAccount('mintAuthority'),
+            multisigMintAuthority: resolveAccount('multisigMintAuthority'),
+        },
+        SplTokenBurnCheckedInstruction: {
+            account: resolveAccount('account'),
+            authority: resolveAccount('authority'),
+            mint: resolveAccount('mint'),
+            multisigAuthority: resolveAccount('multisigAuthority'),
+        },
+        SplTokenSyncNativeInstruction: {
+            account: resolveAccount('account'),
+        },
+        SplTokenGetAccountDataSizeInstruction: {
+            mint: resolveAccount('mint'),
+        },
+        SplTokenAmountToUiAmountInstruction: {
+            mint: resolveAccount('mint'),
+        },
+        SplTokenUiAmountToAmountInstruction: {
+            mint: resolveAccount('mint'),
+        },
+        SplTokenInitializeMintCloseAuthorityInstruction: {
+            mint: resolveAccount('mint'),
+            newAuthority: resolveAccount('newAuthority'),
+        },
+        Lockup: {
+            custodian: resolveAccount('custodian'),
+        },
+        StakeInitializeInstructionDataAuthorized: {
+            staker: resolveAccount('staker'),
+            withdrawer: resolveAccount('withdrawer'),
+        },
+        StakeInitializeInstruction: {
+            stakeAccount: resolveAccount('stakeAccount'),
+        },
+        StakeAuthorizeInstruction: {
+            authority: resolveAccount('authority'),
+            custodian: resolveAccount('custodian'),
+            newAuthority: resolveAccount('newAuthority'),
+            stakeAccount: resolveAccount('stakeAccount'),
+        },
+        StakeDelegateStakeInstruction: {
+            stakeAccount: resolveAccount('stakeAccount'),
+            stakeAuthority: resolveAccount('stakeAuthority'),
+            stakeConfigAccount: resolveAccount('stakeConfigAccount'),
+            voteAccount: resolveAccount('voteAccount'),
+        },
+        StakeSplitInstruction: {
+            newSplitAccount: resolveAccount('newSplitAccount'),
+            stakeAccount: resolveAccount('stakeAccount'),
+            stakeAuthority: resolveAccount('stakeAuthority'),
+        },
+        StakeWithdrawInstruction: {
+            destination: resolveAccount('destination'),
+            stakeAccount: resolveAccount('stakeAccount'),
+            withdrawAuthority: resolveAccount('withdrawAuthority'),
+        },
+        StakeDeactivateInstruction: {
+            stakeAccount: resolveAccount('stakeAccount'),
+            stakeAuthority: resolveAccount('stakeAuthority'),
+        },
+        StakeSetLockupInstruction: {
+            custodian: resolveAccount('custodian'),
+            stakeAccount: resolveAccount('stakeAccount'),
+        },
+        StakeMergeInstruction: {
+            destination: resolveAccount('destination'),
+            source: resolveAccount('source'),
+            stakeAuthority: resolveAccount('stakeAuthority'),
+        },
+        StakeAuthorizeWithSeedInstruction: {
+            authorityBase: resolveAccount('authorityBase'),
+            authorityOwner: resolveAccount('authorityOwner'),
+            custodian: resolveAccount('custodian'),
+            newAuthorized: resolveAccount('newAuthorized'),
+            stakeAccount: resolveAccount('stakeAccount'),
+        },
+        StakeInitializeCheckedInstructionDataAuthorized: {
+            staker: resolveAccount('staker'),
+            withdrawer: resolveAccount('withdrawer'),
+        },
+        StakeAuthorizeCheckedInstruction: {
+            authority: resolveAccount('authority'),
+            custodian: resolveAccount('custodian'),
+            newAuthority: resolveAccount('newAuthority'),
+            stakeAccount: resolveAccount('stakeAccount'),
+        },
+        StakeAuthorizeCheckedWithSeedInstruction: {
+            authorityBase: resolveAccount('authorityBase'),
+            authorityOwner: resolveAccount('authorityOwner'),
+            custodian: resolveAccount('custodian'),
+            newAuthorized: resolveAccount('newAuthorized'),
+            stakeAccount: resolveAccount('stakeAccount'),
+        },
+        StakeSetLockupCheckedInstruction: {
+            custodian: resolveAccount('custodian'),
+            stakeAccount: resolveAccount('stakeAccount'),
+        },
+        StakeDeactivateDelinquentInstruction: {
+            referenceVoteAccount: resolveAccount('referenceVoteAccount'),
+            stakeAccount: resolveAccount('stakeAccount'),
+            voteAccount: resolveAccount('voteAccount'),
+        },
+        StakeRedelegateInstruction: {
+            newStakeAccount: resolveAccount('newStakeAccount'),
+            stakeAccount: resolveAccount('stakeAccount'),
+            stakeAuthority: resolveAccount('stakeAuthority'),
+            stakeConfigAccount: resolveAccount('stakeConfigAccount'),
+            voteAccount: resolveAccount('voteAccount'),
+        },
+        CreateAccountInstruction: {
+            newAccount: resolveAccount('newAccount'),
+            owner: resolveAccount('owner'),
+            source: resolveAccount('source'),
+        },
+        AssignInstruction: {
+            account: resolveAccount('account'),
+            owner: resolveAccount('owner'),
+        },
+        TransferInstruction: {
+            destination: resolveAccount('destination'),
+            source: resolveAccount('source'),
+        },
+        CreateAccountWithSeedInstruction: {
+            base: resolveAccount('base'),
+            owner: resolveAccount('owner'),
+            seed: resolveAccount('seed'),
+        },
+        AdvanceNonceAccountInstruction: {
+            nonceAccount: resolveAccount('nonceAccount'),
+            nonceAuthority: resolveAccount('nonceAuthority'),
+        },
+        WithdrawNonceAccountInstruction: {
+            destination: resolveAccount('destination'),
+            nonceAccount: resolveAccount('nonceAccount'),
+            nonceAuthority: resolveAccount('nonceAuthority'),
+        },
+        InitializeNonceAccountInstruction: {
+            nonceAccount: resolveAccount('nonceAccount'),
+            nonceAuthority: resolveAccount('nonceAuthority'),
+        },
+        AuthorizeNonceAccountInstruction: {
+            newAuthorized: resolveAccount('newAuthorized'),
+            nonceAccount: resolveAccount('nonceAccount'),
+            nonceAuthority: resolveAccount('nonceAuthority'),
+        },
+        UpgradeNonceAccountInstruction: {
+            nonceAccount: resolveAccount('nonceAccount'),
+            nonceAuthority: resolveAccount('nonceAuthority'),
+        },
+        AllocateInstruction: {
+            account: resolveAccount('account'),
+        },
+        AllocateWithSeedInstruction: {
+            account: resolveAccount('account'),
+            owner: resolveAccount('owner'),
+        },
+        AssignWithSeedInstruction: {
+            account: resolveAccount('account'),
+            owner: resolveAccount('owner'),
+        },
+        TransferWithSeedInstruction: {
+            destination: resolveAccount('destination'),
+            source: resolveAccount('source'),
+            sourceOwner: resolveAccount('sourceOwner'),
+        },
+        VoteInitializeAccountInstruction: {
+            authorizedVoter: resolveAccount('authorizedVoter'),
+            authorizedWithdrawer: resolveAccount('authorizedWithdrawer'),
+            node: resolveAccount('node'),
+            voteAccount: resolveAccount('voteAccount'),
+        },
+        VoteAuthorizeInstruction: {
+            authority: resolveAccount('authority'),
+            newAuthority: resolveAccount('newAuthority'),
+            voteAccount: resolveAccount('voteAccount'),
+        },
+        VoteAuthorizeWithSeedInstruction: {
+            authorityOwner: resolveAccount('authorityOwner'),
+            newAuthority: resolveAccount('newAuthority'),
+            voteAccount: resolveAccount('voteAccount'),
+        },
+        VoteAuthorizeCheckedWithSeedInstruction: {
+            authorityOwner: resolveAccount('authorityOwner'),
+            newAuthority: resolveAccount('newAuthority'),
+            voteAccount: resolveAccount('voteAccount'),
+        },
+        VoteVoteInstruction: {
+            voteAccount: resolveAccount('voteAccount'),
+            voteAuthority: resolveAccount('voteAuthority'),
+        },
+        VoteUpdateVoteStateInstruction: {
+            voteAccount: resolveAccount('voteAccount'),
+            voteAuthority: resolveAccount('voteAuthority'),
+        },
+        VoteUpdateVoteStateSwitchInstruction: {
+            voteAccount: resolveAccount('voteAccount'),
+            voteAuthority: resolveAccount('voteAuthority'),
+        },
+        VoteCompactUpdateVoteStateInstruction: {
+            voteAccount: resolveAccount('voteAccount'),
+            voteAuthority: resolveAccount('voteAuthority'),
+        },
+        VoteCompactUpdateVoteStateSwitchInstruction: {
+            voteAccount: resolveAccount('voteAccount'),
+            voteAuthority: resolveAccount('voteAuthority'),
+        },
+        VoteWithdrawInstruction: {
+            voteAccount: resolveAccount('voteAccount'),
+            withdrawAuthority: resolveAccount('withdrawAuthority'),
+        },
+        VoteUpdateValidatorIdentityInstruction: {
+            newValidatorIdentity: resolveAccount('newValidatorIdentity'),
+            voteAccount: resolveAccount('voteAccount'),
+            withdrawAuthority: resolveAccount('withdrawAuthority'),
+        },
+        VoteUpdateCommissionInstruction: {
+            voteAccount: resolveAccount('voteAccount'),
+            withdrawAuthority: resolveAccount('withdrawAuthority'),
+        },
+        VoteVoteSwitchInstruction: {
+            voteAccount: resolveAccount('voteAccount'),
+            voteAuthority: resolveAccount('voteAuthority'),
+        },
+        VoteAuthorizeCheckedInstruction: {
+            authority: resolveAccount('authority'),
+            newAuthority: resolveAccount('newAuthority'),
+            voteAccount: resolveAccount('voteAccount'),
+        },
+    };
+}
+
+export function buildInstructionSchema(instructions?: AstConfig): [Record<string, unknown>, string] {
+    if (instructions) {
+        const resolvers = {
+            ...instructionResolvers(instructions.resolveTypeExtension),
+            ...instructions.resolvers,
+        };
+        const typeDefs = [instructionTypeDefs, ...instructions.typeDefs].join('\n');
+        return [resolvers, typeDefs];
+    }
+    return [instructionResolvers(), instructionTypeDefs];
+}


### PR DESCRIPTION
This PR is merely a concept for now, but it introduces the idea of custom
parsing "plugins" for the GraphQL API.

Namely, this change would allow users to plug their IDL or Kinobi Tree into
`createJsonRpcGraphQL(..)` in order to customize the GraphQL schema.

Once customized, the schema can support custom IDL-defined types in pure
GraphQL, both in queries _and_ in introspection!

This would be greatly convenient for users wishing to parse out specific program
data that isn't supported by the canonical `jsonParsed`.

---

One major drawback here, which we would need to sort out before
productionalizing such a feature, is the fact that decoding
account/instruction/return data is happening on the client, not the server, and
has an O(n^2) performance rating relative to the size or quantity of IDLs or
Kinobi Trees provided.

Specifically, the library would have to attempt to decode some data string using
each configured decoder until it finds success or reaches the end of the decoder
set.

Even more troublesome, it _could_ decode something incorrectly and just not
fail, meaning you'd have the wrong data.

---

Regardless, if the community finds this feature useful - such as explorers,
indexers, etc. - we can explore optimizations.
