### PR TITLE
refactor(experimental): add bigint support to `fast-stable-stringify`

### DIFF
--- a/packages/rpc-graphql/src/loaders/account.ts
+++ b/packages/rpc-graphql/src/loaders/account.ts
@@ -1,12 +1,10 @@
 import { SolanaRpcMethods } from '@solana/rpc-core';
 import DataLoader from 'dataloader';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import fastStableStringify from 'fast-stable-stringify';
 import { GraphQLResolveInfo } from 'graphql';
 
 import type { Rpc } from '../context';
 import { AccountQueryArgs } from '../schema/account';
+import { cacheKeyFn } from './common/cache-key-fn';
 import { onlyPresentFieldRequested } from './common/resolve-info';
 import { transformLoadedAccount } from './transformers/account';
 
@@ -41,7 +39,7 @@ function createAccountBatchLoadFn(rpc: Rpc) {
 }
 
 export function createAccountLoader(rpc: Rpc) {
-    const loader = new DataLoader(createAccountBatchLoadFn(rpc), { cacheKeyFn: fastStableStringify });
+    const loader = new DataLoader(createAccountBatchLoadFn(rpc), { cacheKeyFn });
     return {
         load: async (args: AccountQueryArgs, info?: GraphQLResolveInfo) => {
             if (onlyPresentFieldRequested('address', info)) {

--- a/packages/rpc-graphql/src/loaders/block.ts
+++ b/packages/rpc-graphql/src/loaders/block.ts
@@ -1,12 +1,10 @@
 import { SolanaRpcMethods } from '@solana/rpc-core';
 import DataLoader from 'dataloader';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import fastStableStringify from 'fast-stable-stringify';
 import { GraphQLResolveInfo } from 'graphql';
 
 import type { Rpc } from '../context';
 import { BlockQueryArgs } from '../schema/block';
+import { cacheKeyFn } from './common/cache-key-fn';
 import { onlyPresentFieldRequested } from './common/resolve-info';
 import { transformLoadedBlock } from './transformers/block';
 
@@ -49,7 +47,7 @@ function createBlockBatchLoadFn(rpc: Rpc) {
 }
 
 export function createBlockLoader(rpc: Rpc) {
-    const loader = new DataLoader(createBlockBatchLoadFn(rpc), { cacheKeyFn: fastStableStringify });
+    const loader = new DataLoader(createBlockBatchLoadFn(rpc), { cacheKeyFn });
     return {
         load: async (args: BlockQueryArgs, info?: GraphQLResolveInfo) => {
             if (onlyPresentFieldRequested('slot', info)) {

--- a/packages/rpc-graphql/src/loaders/common/cache-key-fn.ts
+++ b/packages/rpc-graphql/src/loaders/common/cache-key-fn.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import fastStableStringify from 'fast-stable-stringify';
+
+// This is a temporary fix for now. It is not optimized for performance,
+// however, this library's parameter sets used for cache keys are relatively
+// small, so it should not be a problem.
+//
+// `fast-stable-stringify` does not support `bigint` values, and some
+// alternatives seem to opt for converting `bigint` to number. It's much more
+// preferable, in the context of cache keys for relatively small parameter
+// sets, to convert `bigint` to `string` instead.
+//
+// Although one might suggest setting the global `BigInt.prototype.toString`,
+// however, `fast-stable-stringify` attempts to identify boolean, object,
+// function, undefined, then string before defaulting to number, so there is no
+// feasible way to inject `BigInt.prototype.toString` into the call stack.
+//
+// This function converts any `bigint` values in the object to `string` values,
+// then passes the modified object to `fast-stable-stringify`.
+export function cacheKeyFn(obj: any) {
+    function bigintToString(obj: any) {
+        if (typeof obj === 'bigint') {
+            return obj.toString();
+        }
+        if (typeof obj === 'object') {
+            const newObj = {};
+            for (const key in obj) {
+                // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+                // @ts-ignore
+                newObj[key] = bigintToString(obj[key]);
+            }
+            return newObj;
+        }
+        return obj;
+    }
+    return fastStableStringify(bigintToString(obj));
+}

--- a/packages/rpc-graphql/src/loaders/program-accounts.ts
+++ b/packages/rpc-graphql/src/loaders/program-accounts.ts
@@ -1,13 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { SolanaRpcMethods } from '@solana/rpc-core';
 import DataLoader from 'dataloader';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import fastStableStringify from 'fast-stable-stringify';
 import { GraphQLResolveInfo } from 'graphql';
 
 import type { Rpc } from '../context';
 import { ProgramAccountsQueryArgs } from '../schema/program-accounts';
+import { cacheKeyFn } from './common/cache-key-fn';
 import { onlyPresentFieldRequested } from './common/resolve-info';
 import { transformLoadedAccount } from './transformers/account';
 
@@ -57,7 +55,7 @@ function createProgramAccountsBatchLoadFn(rpc: Rpc) {
 }
 
 export function createProgramAccountsLoader(rpc: Rpc) {
-    const loader = new DataLoader(createProgramAccountsBatchLoadFn(rpc), { cacheKeyFn: fastStableStringify });
+    const loader = new DataLoader(createProgramAccountsBatchLoadFn(rpc), { cacheKeyFn });
     return {
         load: async (args: ProgramAccountsQueryArgs, info?: GraphQLResolveInfo) => {
             if (onlyPresentFieldRequested('programAddress', info)) {

--- a/packages/rpc-graphql/src/loaders/transaction.ts
+++ b/packages/rpc-graphql/src/loaders/transaction.ts
@@ -1,12 +1,10 @@
 import { SolanaRpcMethods } from '@solana/rpc-core';
 import DataLoader from 'dataloader';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import fastStableStringify from 'fast-stable-stringify';
 import { GraphQLResolveInfo } from 'graphql';
 
 import type { Rpc } from '../context';
 import { TransactionQueryArgs } from '../schema/transaction';
+import { cacheKeyFn } from './common/cache-key-fn';
 import { onlyPresentFieldRequested } from './common/resolve-info';
 import { transformLoadedTransaction } from './transformers/transaction';
 
@@ -64,7 +62,7 @@ function createTransactionBatchLoadFn(rpc: Rpc) {
 }
 
 export function createTransactionLoader(rpc: Rpc) {
-    const loader = new DataLoader(createTransactionBatchLoadFn(rpc), { cacheKeyFn: fastStableStringify });
+    const loader = new DataLoader(createTransactionBatchLoadFn(rpc), { cacheKeyFn });
     return {
         load: async (args: TransactionQueryArgs, info?: GraphQLResolveInfo) => {
             if (onlyPresentFieldRequested('signature', info)) {


### PR DESCRIPTION
This PR adds custom `bigint` support to the cache key functions used by the
resolvers within `DataLoader`.

The library used to create these cache keys - `fast-stable-stringify` - does not
support `bigint`, so I've added a custom `cacheKey` function to convert `bigint`
to `string` in all parameter objects before handing the object over to
`fast-stable-stringify`.

This somewhat defeats the "fast" purpose of `fast-stable-stringify`, but as
mentioned in the function's comments, considering the size of these parameter
objects, the effect should be negligible.

Closes #1986
