### PR TITLE
refactor(experimental): provide account encoding on the data field

### DIFF
--- a/packages/rpc-graphql/src/__tests__/account-test.ts
+++ b/packages/rpc-graphql/src/__tests__/account-test.ts
@@ -228,15 +228,12 @@ describe('account', () => {
             // See scripts/fixtures/gpa1.json
             const variableValues = {
                 address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
-                encoding: 'BASE_58',
             };
             const source = /* GraphQL */ `
-                query testQuery($address: String!, $encoding: AccountEncoding) {
-                    account(address: $address, encoding: $encoding) {
+                query testQuery($address: String!) {
+                    account(address: $address) {
                         address
-                        ... on AccountBase58 {
-                            data
-                        }
+                        dataBase58: data(encoding: BASE_58)
                     }
                 }
             `;
@@ -245,7 +242,7 @@ describe('account', () => {
                 data: {
                     account: {
                         address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
-                        data: '2Uw1bpnsXxu3e',
+                        dataBase58: '2Uw1bpnsXxu3e',
                     },
                 },
             });
@@ -255,15 +252,12 @@ describe('account', () => {
             // See scripts/fixtures/gpa1.json
             const variableValues = {
                 address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
-                encoding: 'BASE_64',
             };
             const source = /* GraphQL */ `
-                query testQuery($address: String!, $encoding: AccountEncoding) {
-                    account(address: $address, encoding: $encoding) {
+                query testQuery($address: String!) {
+                    account(address: $address) {
                         address
-                        ... on AccountBase64 {
-                            data
-                        }
+                        dataBase64: data(encoding: BASE_64)
                     }
                 }
             `;
@@ -272,7 +266,7 @@ describe('account', () => {
                 data: {
                     account: {
                         address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
-                        data: 'dGVzdCBkYXRh',
+                        dataBase64: 'dGVzdCBkYXRh',
                     },
                 },
             });
@@ -285,12 +279,10 @@ describe('account', () => {
                 encoding: 'BASE_64_ZSTD',
             };
             const source = /* GraphQL */ `
-                query testQuery($address: String!, $encoding: AccountEncoding) {
-                    account(address: $address, encoding: $encoding) {
+                query testQuery($address: String!) {
+                    account(address: $address) {
                         address
-                        ... on AccountBase64Zstd {
-                            data
-                        }
+                        dataBase64Zstd: data(encoding: BASE_64_ZSTD)
                     }
                 }
             `;
@@ -299,45 +291,7 @@ describe('account', () => {
                 data: {
                     account: {
                         address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
-                        data: 'KLUv/QBYSQAAdGVzdCBkYXRh',
-                    },
-                },
-            });
-        });
-        it('can get account data as jsonParsed', async () => {
-            expect.assertions(2);
-            const source = /* GraphQL */ `
-                query testQuery($address: String!) {
-                    account(address: $address, encoding: PARSED) {
-                        ... on AccountBase64 {
-                            data
-                        }
-                        ... on MintAccount {
-                            supply
-                        }
-                    }
-                }
-            `;
-            const resultParsed = await rpcGraphQL.query(source, {
-                // See scripts/fixtures/spl-token-mint-account.json
-                address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
-            });
-            expect(resultParsed).toMatchObject({
-                data: {
-                    account: {
-                        supply: expect.any(String),
-                    },
-                },
-            });
-            // Defaults to base64 if can't be parsed
-            const resultBase64 = await rpcGraphQL.query(source, {
-                // See scripts/fixtures/gpa1.json
-                address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
-            });
-            expect(resultBase64).toMatchObject({
-                data: {
-                    account: {
-                        data: 'dGVzdCBkYXRh',
+                        dataBase64Zstd: 'KLUv/QBYSQAAdGVzdCBkYXRh',
                     },
                 },
             });
@@ -361,6 +315,39 @@ describe('account', () => {
             expect(result).toMatchObject({
                 data: {
                     account: {
+                        supply: expect.any(String),
+                    },
+                },
+            });
+        });
+        it('can get account data as base58, base64, base64+zstd, and jsonParsed at the same time', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/spl-token-mint-account.json
+            const variableValues = {
+                address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+            };
+            const source = /* GraphQL */ `
+                query testQuery($address: String!) {
+                    account(address: $address) {
+                        dataBase58: data(encoding: BASE_58)
+                        dataBase64: data(encoding: BASE_64)
+                        dataBase64Zstd: data(encoding: BASE_64_ZSTD)
+                        ... on MintAccount {
+                            supply
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    account: {
+                        dataBase58:
+                            'DK9N6ppsTv6i3RBVVA7PCUXGnybDuNQKwFKKpmcEJ5RqfZ4HzeWRbdV32h1Z1QPshdhDChwWSYH4EaBZSS7EJC48fBkv3Lh6R8YdSCUxsSpEWQX',
+                        dataBase64:
+                            'AQAAAOkoOVUJZf/U1krKr0bUXfcxjltPV8kMSH1gYl2Cm4N78eLlNFwmdhcGAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==',
+                        dataBase64Zstd:
+                            'KLUv/QBYtQEA9AIBAAAA6Sg5VQll/9TWSsqvRtRd9zGOW09XyQxIfWBiXYKbg3vx4uU0XCZ2FwYBAAEAR4Iy',
                         supply: expect.any(String),
                     },
                 },

--- a/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/program-accounts-test.ts
@@ -86,17 +86,14 @@ describe('programAccounts', () => {
             // See scripts/fixtures/gpa2-1.json, scripts/fixtures/gpa2-2.json,
             const variableValues = {
                 commitment: 'confirmed',
-                encoding: 'BASE_58',
                 programAddress: 'AmtpVzo6H6qQCP9dH9wfu5hfa8kKaAFpTJ4aamPYR6V6',
             };
             const source = /* GraphQL */ `
-                query testQuery($programAddress: String!, $commitment: Commitment, $encoding: AccountEncoding) {
-                    programAccounts(programAddress: $programAddress, commitment: $commitment, encoding: $encoding) {
+                query testQuery($programAddress: String!, $commitment: Commitment) {
+                    programAccounts(programAddress: $programAddress, commitment: $commitment) {
                         address
+                        dataBase58: data(encoding: BASE_58)
                         executable
-                        ... on AccountBase58 {
-                            data
-                        }
                     }
                 }
             `;
@@ -106,12 +103,12 @@ describe('programAccounts', () => {
                     programAccounts: expect.arrayContaining([
                         {
                             address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
-                            data: '2Uw1bpnsXxu3e',
+                            dataBase58: '2Uw1bpnsXxu3e',
                             executable: false,
                         },
                         {
                             address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
-                            data: '2Uw1bpnsXxu3e',
+                            dataBase58: '2Uw1bpnsXxu3e',
                             executable: false,
                         },
                     ]),
@@ -123,17 +120,14 @@ describe('programAccounts', () => {
             // See scripts/fixtures/gpa2-1.json, scripts/fixtures/gpa2-2.json,
             const variableValues = {
                 commitment: 'confirmed',
-                encoding: 'BASE_64',
                 programAddress: 'AmtpVzo6H6qQCP9dH9wfu5hfa8kKaAFpTJ4aamPYR6V6',
             };
             const source = /* GraphQL */ `
-                query testQuery($programAddress: String!, $commitment: Commitment, $encoding: AccountEncoding) {
-                    programAccounts(programAddress: $programAddress, commitment: $commitment, encoding: $encoding) {
+                query testQuery($programAddress: String!, $commitment: Commitment) {
+                    programAccounts(programAddress: $programAddress, commitment: $commitment) {
                         address
+                        dataBase64: data(encoding: BASE_64)
                         executable
-                        ... on AccountBase64 {
-                            data
-                        }
                     }
                 }
             `;
@@ -143,12 +137,12 @@ describe('programAccounts', () => {
                     programAccounts: expect.arrayContaining([
                         {
                             address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
-                            data: 'dGVzdCBkYXRh',
+                            dataBase64: 'dGVzdCBkYXRh',
                             executable: false,
                         },
                         {
                             address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
-                            data: 'dGVzdCBkYXRh',
+                            dataBase64: 'dGVzdCBkYXRh',
                             executable: false,
                         },
                     ]),
@@ -160,17 +154,14 @@ describe('programAccounts', () => {
             // See scripts/fixtures/gpa2-1.json, scripts/fixtures/gpa2-2.json,
             const variableValues = {
                 commitment: 'confirmed',
-                encoding: 'BASE_64_ZSTD',
                 programAddress: 'AmtpVzo6H6qQCP9dH9wfu5hfa8kKaAFpTJ4aamPYR6V6',
             };
             const source = /* GraphQL */ `
-                query testQuery($programAddress: String!, $commitment: Commitment, $encoding: AccountEncoding) {
-                    programAccounts(programAddress: $programAddress, commitment: $commitment, encoding: $encoding) {
+                query testQuery($programAddress: String!, $commitment: Commitment) {
+                    programAccounts(programAddress: $programAddress, commitment: $commitment) {
                         address
+                        dataBase64Zstd: data(encoding: BASE_64_ZSTD)
                         executable
-                        ... on AccountBase64Zstd {
-                            data
-                        }
                     }
                 }
             `;
@@ -180,12 +171,12 @@ describe('programAccounts', () => {
                     programAccounts: expect.arrayContaining([
                         {
                             address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
-                            data: 'KLUv/QBYSQAAdGVzdCBkYXRh',
+                            dataBase64Zstd: 'KLUv/QBYSQAAdGVzdCBkYXRh',
                             executable: false,
                         },
                         {
                             address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
-                            data: 'KLUv/QBYSQAAdGVzdCBkYXRh',
+                            dataBase64Zstd: 'KLUv/QBYSQAAdGVzdCBkYXRh',
                             executable: false,
                         },
                     ]),
@@ -569,25 +560,12 @@ describe('programAccounts', () => {
                         length: 5,
                         offset: 0,
                     },
-                    encoding: 'BASE_58',
                     programAddress: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
                 };
                 const source = /* GraphQL */ `
-                    query testQuery(
-                        $programAddress: String!
-                        $commitment: Commitment
-                        $dataSlice: DataSlice
-                        $encoding: AccountEncoding
-                    ) {
-                        programAccounts(
-                            programAddress: $programAddress
-                            commitment: $commitment
-                            dataSlice: $dataSlice
-                            encoding: $encoding
-                        ) {
-                            ... on AccountBase58 {
-                                data
-                            }
+                    query testQuery($programAddress: String!, $commitment: Commitment, $dataSlice: DataSlice) {
+                        programAccounts(programAddress: $programAddress, commitment: $commitment) {
+                            dataBase58: data(encoding: BASE_58, dataSlice: $dataSlice)
                         }
                     }
                 `;
@@ -596,7 +574,7 @@ describe('programAccounts', () => {
                     data: {
                         programAccounts: expect.arrayContaining([
                             {
-                                data: 'E8f4pET',
+                                dataBase58: 'E8f4pET',
                             },
                         ]),
                     },
@@ -613,25 +591,12 @@ describe('programAccounts', () => {
                         length: 5,
                         offset: 0,
                     },
-                    encoding: 'BASE_64',
                     programAddress: 'DXngmJfjurhnAwbMPgpUGPH6qNvetCKRJ6PiD4ag4PTj',
                 };
                 const source = /* GraphQL */ `
-                    query testQuery(
-                        $programAddress: String!
-                        $commitment: Commitment
-                        $dataSlice: DataSlice
-                        $encoding: AccountEncoding
-                    ) {
-                        programAccounts(
-                            programAddress: $programAddress
-                            commitment: $commitment
-                            dataSlice: $dataSlice
-                            encoding: $encoding
-                        ) {
-                            ... on AccountBase64 {
-                                data
-                            }
+                    query testQuery($programAddress: String!, $commitment: Commitment, $dataSlice: DataSlice) {
+                        programAccounts(programAddress: $programAddress, commitment: $commitment) {
+                            dataBase64: data(encoding: BASE_64, dataSlice: $dataSlice)
                         }
                     }
                 `;
@@ -640,7 +605,7 @@ describe('programAccounts', () => {
                     data: {
                         programAccounts: expect.arrayContaining([
                             {
-                                data: 'dGVzdCA=',
+                                dataBase64: 'dGVzdCA=',
                             },
                         ]),
                     },

--- a/packages/rpc-graphql/src/resolvers/account.ts
+++ b/packages/rpc-graphql/src/resolvers/account.ts
@@ -13,3 +13,19 @@ export const resolveAccount = (fieldName: string) => {
     ) =>
         parent[fieldName] === null ? null : context.loaders.account.load({ ...args, address: parent[fieldName] }, info);
 };
+
+export const resolveAccountData = () => {
+    return (
+        parent: { address: Address },
+        args: { encoding: AccountLoaderArgs['encoding']; dataSlice?: AccountLoaderArgs['dataSlice'] },
+        context: RpcGraphQLContext,
+        info: GraphQLResolveInfo | undefined,
+    ) => {
+        return (
+            context.loaders.account
+                .load({ ...args, address: parent.address }, info)
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                .then((account: any) => account.data)
+        );
+    };
+};

--- a/packages/rpc-graphql/src/schema/account.ts
+++ b/packages/rpc-graphql/src/schema/account.ts
@@ -1,10 +1,11 @@
 /* eslint-disable sort-keys-fix/sort-keys-fix */
-import { resolveAccount } from '../resolvers/account';
+import { resolveAccount, resolveAccountData } from '../resolvers/account';
 
 export const accountTypeDefs = /* GraphQL */ `
     # Account interface
     interface Account {
         address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
         executable: Boolean
         lamports: BigInt
         ownerProgram: Account
@@ -12,32 +13,10 @@ export const accountTypeDefs = /* GraphQL */ `
         rentEpoch: BigInt
     }
 
-    # An account with base58 encoded data
-    type AccountBase58 implements Account {
+    # Base account type
+    type GenericAccount implements Account {
         address: Address
-        data: Base58EncodedBytes
-        executable: Boolean
-        lamports: BigInt
-        ownerProgram: Account
-        space: BigInt
-        rentEpoch: BigInt
-    }
-
-    # An account with base64 encoded data
-    type AccountBase64 implements Account {
-        address: Address
-        data: Base64EncodedBytes
-        executable: Boolean
-        lamports: BigInt
-        ownerProgram: Account
-        space: BigInt
-        rentEpoch: BigInt
-    }
-
-    # An account with base64+zstd encoded data
-    type AccountBase64Zstd implements Account {
-        address: Address
-        data: Base64ZstdEncodedBytes
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
         executable: Boolean
         lamports: BigInt
         ownerProgram: Account
@@ -51,6 +30,7 @@ export const accountTypeDefs = /* GraphQL */ `
     }
     type NonceAccount implements Account {
         address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
         executable: Boolean
         lamports: BigInt
         ownerProgram: Account
@@ -64,6 +44,7 @@ export const accountTypeDefs = /* GraphQL */ `
     # A lookup table account
     type LookupTableAccount implements Account {
         address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
         executable: Boolean
         lamports: BigInt
         ownerProgram: Account
@@ -79,6 +60,7 @@ export const accountTypeDefs = /* GraphQL */ `
     # A mint account
     type MintAccount implements Account {
         address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
         executable: Boolean
         lamports: BigInt
         ownerProgram: Account
@@ -94,6 +76,7 @@ export const accountTypeDefs = /* GraphQL */ `
     # A token account
     type TokenAccount implements Account {
         address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
         executable: Boolean
         lamports: BigInt
         ownerProgram: Account
@@ -134,6 +117,7 @@ export const accountTypeDefs = /* GraphQL */ `
     }
     type StakeAccount implements Account {
         address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
         executable: Boolean
         lamports: BigInt
         ownerProgram: Account
@@ -163,6 +147,7 @@ export const accountTypeDefs = /* GraphQL */ `
     }
     type VoteAccount implements Account {
         address: Address
+        data(encoding: AccountEncoding!, dataSlice: DataSlice): String
         executable: Boolean
         lamports: BigInt
         ownerProgram: Account
@@ -183,15 +168,6 @@ export const accountTypeDefs = /* GraphQL */ `
 export const accountResolvers = {
     Account: {
         __resolveType(account: { encoding: string; programName: string; accountType: string }) {
-            if (account.encoding === 'base58') {
-                return 'AccountBase58';
-            }
-            if (account.encoding === 'base64') {
-                return 'AccountBase64';
-            }
-            if (account.encoding === 'base64+zstd') {
-                return 'AccountBase64Zstd';
-            }
             if (account.encoding === 'jsonParsed') {
                 if (account.programName === 'nonce') {
                     return 'NonceAccount';
@@ -212,32 +188,32 @@ export const accountResolvers = {
                     return 'LookupTableAccount';
                 }
             }
-            return 'AccountBase64';
+            return 'GenericAccount';
         },
+        data: resolveAccountData(),
     },
-    AccountBase58: {
-        ownerProgram: resolveAccount('ownerProgram'),
-    },
-    AccountBase64: {
-        ownerProgram: resolveAccount('ownerProgram'),
-    },
-    AccountBase64Zstd: {
+    GenericAccount: {
+        data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },
     NonceAccount: {
+        data: resolveAccountData(),
         authority: resolveAccount('authority'),
         ownerProgram: resolveAccount('ownerProgram'),
     },
     LookupTableAccount: {
+        data: resolveAccountData(),
         authority: resolveAccount('authority'),
         ownerProgram: resolveAccount('ownerProgram'),
     },
     MintAccount: {
+        data: resolveAccountData(),
         freezeAuthority: resolveAccount('freezeAuthority'),
         mintAuthority: resolveAccount('mintAuthority'),
         ownerProgram: resolveAccount('ownerProgram'),
     },
     TokenAccount: {
+        data: resolveAccountData(),
         mint: resolveAccount('mint'),
         owner: resolveAccount('owner'),
         ownerProgram: resolveAccount('ownerProgram'),
@@ -253,12 +229,14 @@ export const accountResolvers = {
         voter: resolveAccount('voter'),
     },
     StakeAccount: {
+        data: resolveAccountData(),
         ownerProgram: resolveAccount('ownerProgram'),
     },
     VoteAccountDataAuthorizedVoter: {
         authorizedVoter: resolveAccount('authorizedVoter'),
     },
     VoteAccount: {
+        data: resolveAccountData(),
         authorizedWithdrawer: resolveAccount('authorizedWithdrawer'),
         node: resolveAccount('nodePubkey'),
         ownerProgram: resolveAccount('ownerProgram'),

--- a/packages/rpc-graphql/src/schema/common/types.ts
+++ b/packages/rpc-graphql/src/schema/common/types.ts
@@ -5,7 +5,6 @@ export const commonTypeDefs = /* GraphQL */ `
         BASE_58
         BASE_64
         BASE_64_ZSTD
-        PARSED
     }
 
     enum BlockTransactionDetails {
@@ -66,7 +65,6 @@ export const commonResolvers = {
         BASE_58: 'base58',
         BASE_64: 'base64',
         BASE_64_ZSTD: 'base64+zstd',
-        PARSED: 'jsonParsed',
     },
     TokenBalance: {
         mint: resolveAccount('mint'),

--- a/packages/rpc-graphql/src/schema/index.ts
+++ b/packages/rpc-graphql/src/schema/index.ts
@@ -20,8 +20,6 @@ const schemaTypeDefs = /* GraphQL */ `
         account(
             address: String!
             commitment: Commitment
-            dataSlice: DataSlice
-            encoding: AccountEncoding
             minContextSlot: BigInt
         ): Account
         block(
@@ -33,8 +31,6 @@ const schemaTypeDefs = /* GraphQL */ `
         programAccounts(
             programAddress: String!
             commitment: Commitment
-            dataSlice: DataSlice
-            encoding: AccountEncoding
             filters: [ProgramAccountsFilter]
             minContextSlot: BigInt
         ): [Account]


### PR DESCRIPTION
This PR refactors the accounts schema to allow for providing specific account
data encoding _only_ when requesting the `data` field, which is always going to
be a string of encoded data.

Accounts are queried from the RPC as `jsonParsed` by default, so when this field
is provided with an explicit `encoding`, it will return the account's data in
the requested encoding in the `data` field.

Note this means it's now possible to query multiple data encodings on accounts,
as depicted in the tests.

For more context, here's a review comment by @steveluscher on a previous PR:

https://github.com/solana-labs/solana-web3.js/pull/1837#discussion_r1407188113

**Important Note:** This change will cause `programAccounts` queries to spam
the RPC for each account, as the resolver is called from each account's context.
This is remedied in the next commit in the stack.
