### PR TITLE
refactor(experimental): rpc-core: add master union types to API definitions

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__typetests__/common.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/common.ts
@@ -1,0 +1,4 @@
+export function assertNotAProperty<T extends object, TPropName extends string>(
+    _: { [Prop in keyof T]: Prop extends TPropName ? never : T[Prop] },
+    _propName: TPropName,
+): void {}

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-account-info-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-account-info-typetest.ts
@@ -1,0 +1,114 @@
+import { Address } from '@solana/addresses';
+import {
+    Base58EncodedBytes,
+    Base58EncodedDataResponse,
+    Base64EncodedDataResponse,
+    Base64EncodedZStdCompressedDataResponse,
+    Commitment,
+    Rpc,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
+
+import { GetAccountInfoApi } from '../getAccountInfo';
+
+const rpc = null as unknown as Rpc<GetAccountInfoApi>;
+const address = 'Joe11111111111111111111111111111' as Address<'Joe11111111111111111111111111111'>;
+
+// Parameters
+const params = null as unknown as Parameters<GetAccountInfoApi['getAccountInfo']>[1];
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { dataSlice?: { length: number; offset: number } } | undefined;
+params satisfies { encoding?: 'jsonParsed' | 'base58' | 'base64' | 'base64+zstd' } | undefined;
+params satisfies { minContextSlot?: bigint } | undefined;
+
+async () => {
+    {
+        const result = await rpc.getAccountInfo(address, { encoding: 'base64' }).send();
+        if (result.value) {
+            const { data } = result.value;
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        }
+    }
+
+    {
+        const result = await rpc.getAccountInfo(address, { encoding: 'base64+zstd' }).send();
+        if (result.value) {
+            const { data } = result.value;
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+        }
+    }
+
+    {
+        const result = await rpc.getAccountInfo(address, { encoding: 'jsonParsed' }).send();
+        if (result.value) {
+            const { data } = result.value;
+            data satisfies
+                | Readonly<{
+                      program: string;
+                      parsed: {
+                          info?: object;
+                          type: string;
+                      };
+                      space: U64UnsafeBeyond2Pow53Minus1;
+                  }>
+                | Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base64` on its own
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `jsonParsed` on its own
+            data satisfies Readonly<{
+                program: string;
+                parsed: {
+                    info?: object;
+                    type: string;
+                };
+                space: U64UnsafeBeyond2Pow53Minus1;
+            }>;
+        }
+    }
+
+    {
+        const result = await rpc.getAccountInfo(address, { encoding: 'base58' }).send();
+        if (result.value) {
+            const { data } = result.value;
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        }
+    }
+
+    {
+        const result = await rpc.getAccountInfo(address).send();
+        if (result.value) {
+            const { data } = result.value;
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58` data response
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        }
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-block-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-block-typetest.ts
@@ -4,8 +4,10 @@ import type {
     Base58EncodedDataResponse,
     Base64EncodedDataResponse,
     Blockhash,
+    Commitment,
     LamportsUnsafeBeyond2Pow53Minus1,
     Rpc,
+    Slot,
     U64UnsafeBeyond2Pow53Minus1,
 } from '@solana/rpc-types';
 import { TransactionVersion } from '@solana/transactions';
@@ -14,13 +16,7 @@ import { TransactionError } from '../../transaction-error';
 import { TokenBalance } from '../common';
 import { Reward, TransactionStatus } from '../common-transactions';
 import { GetBlockApi } from '../getBlock';
-
-function assertNotAProperty<T extends object, TPropName extends string>(
-    _: { [Prop in keyof T]: Prop extends TPropName ? never : T[Prop] },
-    _propName: TPropName,
-): void {}
-
-const rpc = null as unknown as Rpc<GetBlockApi>;
+import { assertNotAProperty } from './common';
 
 function assertBase(
     response: {
@@ -38,12 +34,23 @@ function assertBase(
     response.previousBlockhash satisfies string;
 }
 
+const rpc = null as unknown as Rpc<GetBlockApi>;
+const slot = 0n as Slot;
+
+// Parameters
+const params = null as unknown as Parameters<GetBlockApi['getBlock']>[1];
+params satisfies { commitment?: Omit<Commitment, 'processed'> } | undefined;
+params satisfies { encoding?: 'jsonParsed' | 'json' | 'base58' | 'base64' } | undefined;
+params satisfies { maxSupportedTransactionVersion?: 'legacy' | 0 } | undefined;
+params satisfies { rewards?: boolean } | undefined;
+params satisfies { transactionDetails?: 'accounts' | 'full' | 'none' | 'signatures' } | undefined;
+
 async () => {
     // First overload
     // Rewards set to `false`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 rewards: false,
                 transactionDetails: 'none',
@@ -60,7 +67,7 @@ async () => {
     // Rewards set to `false`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'processed',
                 encoding: 'base64',
                 maxSupportedTransactionVersion: 0,
@@ -79,7 +86,7 @@ async () => {
     // Rewards defaults to `true`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 transactionDetails: 'none',
             })
@@ -95,7 +102,7 @@ async () => {
     // Rewards defaults to `true`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'confirmed',
                 encoding: 'base58',
                 maxSupportedTransactionVersion: 0,
@@ -113,7 +120,7 @@ async () => {
     // Rewards set to `true`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 rewards: true,
                 transactionDetails: 'none',
@@ -130,7 +137,7 @@ async () => {
     // Rewards set to `true`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'confirmed',
                 encoding: 'base58',
                 maxSupportedTransactionVersion: 0,
@@ -149,7 +156,7 @@ async () => {
     // Rewards set to `false`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 rewards: false,
                 transactionDetails: 'signatures',
@@ -167,7 +174,7 @@ async () => {
     // Rewards set to `false`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'confirmed',
                 encoding: 'json',
                 maxSupportedTransactionVersion: 0,
@@ -187,7 +194,7 @@ async () => {
     // Rewards defaults to `true`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 transactionDetails: 'signatures',
             })
@@ -204,7 +211,7 @@ async () => {
     // Rewards defaults to `true`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'confirmed',
                 encoding: 'jsonParsed',
                 maxSupportedTransactionVersion: 0,
@@ -223,7 +230,7 @@ async () => {
     // Rewards set to `true`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 rewards: true,
                 transactionDetails: 'signatures',
@@ -241,7 +248,7 @@ async () => {
     // Rewards set to `true`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'confirmed',
                 encoding: 'jsonParsed',
                 maxSupportedTransactionVersion: 0,
@@ -299,7 +306,7 @@ async () => {
     // Max supported transaction version set to 0
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 maxSupportedTransactionVersion: 0,
                 rewards: false,
@@ -318,7 +325,7 @@ async () => {
     // Max supported transaction version set to 0
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'confirmed',
                 encoding: 'base64',
                 maxSupportedTransactionVersion: 0,
@@ -338,7 +345,7 @@ async () => {
     // Max supported transaction version defaults to `legacy`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 rewards: false,
                 transactionDetails: 'accounts',
@@ -362,7 +369,7 @@ async () => {
     // Max supported transaction version defaults to `legacy`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'confirmed',
                 encoding: 'base64',
                 rewards: false,
@@ -387,7 +394,7 @@ async () => {
     // Max supported transaction version set to 0
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 maxSupportedTransactionVersion: 0,
                 transactionDetails: 'accounts',
@@ -405,7 +412,7 @@ async () => {
     // Max supported transaction version set to 0
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'confirmed',
                 encoding: 'base64',
                 maxSupportedTransactionVersion: 0,
@@ -424,7 +431,7 @@ async () => {
     // Max supported transaction version set to 0
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 maxSupportedTransactionVersion: 0,
                 rewards: true,
@@ -443,7 +450,7 @@ async () => {
     // Max supported transaction version set to 0
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 commitment: 'confirmed',
                 encoding: 'base64',
                 maxSupportedTransactionVersion: 0,
@@ -463,7 +470,7 @@ async () => {
     // Max supported transaction version defaults to `legacy`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 transactionDetails: 'accounts',
             })
@@ -484,7 +491,7 @@ async () => {
     // Max supported transaction version defaults to `legacy`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 rewards: true,
                 transactionDetails: 'accounts',
@@ -552,7 +559,7 @@ async () => {
     // Transaction details default to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base58',
                 maxSupportedTransactionVersion: 0,
@@ -573,7 +580,7 @@ async () => {
     // Transaction details set to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base58',
                 maxSupportedTransactionVersion: 0,
@@ -595,7 +602,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base58',
                 rewards: false,
@@ -619,7 +626,7 @@ async () => {
     // Transaction details set to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base58',
                 rewards: false,
@@ -644,7 +651,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base58',
                 maxSupportedTransactionVersion: 0,
@@ -664,7 +671,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base58',
                 maxSupportedTransactionVersion: 0,
@@ -685,7 +692,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base58',
             })
@@ -708,7 +715,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base58',
                 rewards: true,
@@ -776,7 +783,7 @@ async () => {
     // Transaction details default to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base64',
                 maxSupportedTransactionVersion: 0,
@@ -797,7 +804,7 @@ async () => {
     // Transaction details set to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base64',
                 maxSupportedTransactionVersion: 0,
@@ -819,7 +826,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base64',
                 rewards: false,
@@ -843,7 +850,7 @@ async () => {
     // Transaction details set to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base64',
                 rewards: false,
@@ -868,7 +875,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base64',
                 maxSupportedTransactionVersion: 0,
@@ -888,7 +895,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'base64',
             })
@@ -1000,7 +1007,7 @@ async () => {
     // Transaction details default to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'jsonParsed',
                 maxSupportedTransactionVersion: 0,
@@ -1021,7 +1028,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'jsonParsed',
                 rewards: false,
@@ -1045,7 +1052,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'jsonParsed',
                 maxSupportedTransactionVersion: 0,
@@ -1066,7 +1073,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'jsonParsed',
             })
@@ -1148,7 +1155,7 @@ async () => {
     // Transaction details default to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 maxSupportedTransactionVersion: 0,
                 rewards: false,
@@ -1168,7 +1175,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 encoding: 'json',
                 maxSupportedTransactionVersion: 0,
@@ -1189,7 +1196,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 rewards: false,
             })
@@ -1212,7 +1219,7 @@ async () => {
     // Transaction details defaults to `full`
     {
         const response = await rpc
-            .getBlock(0n, {
+            .getBlock(slot, {
                 // No extra configs
                 maxSupportedTransactionVersion: 0,
             })
@@ -1230,7 +1237,7 @@ async () => {
     // Encoding defaults to `json`
     // Transaction details defaults to `full`
     {
-        const response = await rpc.getBlock(0n).send();
+        const response = await rpc.getBlock(slot).send();
         if (response) {
             assertBase(response);
             response.transactions satisfies readonly ExpectedTransactionForFullJsonLegacy[];
@@ -1244,7 +1251,7 @@ async () => {
 
     // Twenty-fourth overload with configs
     {
-        const response = await rpc.getBlock(0n, { commitment: 'confirmed' }).send();
+        const response = await rpc.getBlock(slot, { commitment: 'confirmed' }).send();
         if (response) {
             assertBase(response);
             response.transactions satisfies readonly ExpectedTransactionForFullJsonLegacy[];

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-program-accounts-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-program-accounts-typetest.ts
@@ -1,0 +1,321 @@
+import { Address } from '@solana/addresses';
+import {
+    Base58EncodedBytes,
+    Base58EncodedDataResponse,
+    Base64EncodedDataResponse,
+    Base64EncodedZStdCompressedDataResponse,
+    Commitment,
+    Rpc,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
+
+import { GetProgramAccountsDatasizeFilter, GetProgramAccountsMemcmpFilter } from '../common';
+import { GetProgramAccountsApi } from '../getProgramAccounts';
+import { assertNotAProperty } from './common';
+
+const rpc = null as unknown as Rpc<GetProgramAccountsApi>;
+const programAddress = 'JoeProgram11111111111111111111111' as Address<'JoeProgram1111111111111111111111'>;
+
+// Parameters
+const params = null as unknown as Parameters<GetProgramAccountsApi['getProgramAccounts']>[1];
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { dataSlice?: { length: number; offset: number } } | undefined;
+params satisfies { filters?: (GetProgramAccountsMemcmpFilter | GetProgramAccountsDatasizeFilter)[] } | undefined;
+params satisfies { encoding?: 'jsonParsed' | 'base58' | 'base64' | 'base64+zstd' } | undefined;
+params satisfies { minContextSlot?: bigint } | undefined;
+params satisfies { withContext?: boolean } | undefined;
+
+async () => {
+    // `base64` with context
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { encoding: 'base64', withContext: true }).send();
+        result.context.slot satisfies bigint;
+        result.value.forEach(a => {
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    // `base64` without context
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { encoding: 'base64' }).send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    // `base64` without context (explicit)
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { encoding: 'base64', withContext: false }).send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    // `base64+zstd` with context
+    {
+        const result = await rpc
+            .getProgramAccounts(programAddress, { encoding: 'base64+zstd', withContext: true })
+            .send();
+        result.context.slot satisfies bigint;
+        result.value.forEach(a => {
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            a.account.data satisfies Base64EncodedDataResponse;
+        });
+    }
+
+    // `base64+zstd` without context
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { encoding: 'base64+zstd' }).send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            a.account.data satisfies Base64EncodedDataResponse;
+        });
+    }
+
+    // `base64+zstd` without context (explicit)
+    {
+        const result = await rpc
+            .getProgramAccounts(programAddress, { encoding: 'base64+zstd', withContext: false })
+            .send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            a.account.data satisfies Base64EncodedDataResponse;
+        });
+    }
+
+    // `jsonParsed` with context
+    {
+        const result = await rpc
+            .getProgramAccounts(programAddress, { encoding: 'jsonParsed', withContext: true })
+            .send();
+        result.context.slot satisfies bigint;
+        result.value.forEach(a => {
+            a.account.data satisfies
+                | Readonly<{
+                      program: string;
+                      parsed: {
+                          info?: object;
+                          type: string;
+                      };
+                      space: U64UnsafeBeyond2Pow53Minus1;
+                  }>
+                | Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base64` on its own
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `jsonParsed` on its own
+            a.account.data satisfies Readonly<{
+                program: string;
+                parsed: {
+                    info?: object;
+                    type: string;
+                };
+                space: U64UnsafeBeyond2Pow53Minus1;
+            }>;
+        });
+    }
+
+    // `jsonParsed` without context
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { encoding: 'jsonParsed' }).send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies
+                | Readonly<{
+                      program: string;
+                      parsed: {
+                          info?: object;
+                          type: string;
+                      };
+                      space: U64UnsafeBeyond2Pow53Minus1;
+                  }>
+                | Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base64` on its own
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `jsonParsed` on its own
+            a.account.data satisfies Readonly<{
+                program: string;
+                parsed: {
+                    info?: object;
+                    type: string;
+                };
+                space: U64UnsafeBeyond2Pow53Minus1;
+            }>;
+        });
+    }
+
+    // `jsonParsed` without context (explicit)
+    {
+        const result = await rpc
+            .getProgramAccounts(programAddress, { encoding: 'jsonParsed', withContext: false })
+            .send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies
+                | Readonly<{
+                      program: string;
+                      parsed: {
+                          info?: object;
+                          type: string;
+                      };
+                      space: U64UnsafeBeyond2Pow53Minus1;
+                  }>
+                | Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base64` on its own
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `jsonParsed` on its own
+            a.account.data satisfies Readonly<{
+                program: string;
+                parsed: {
+                    info?: object;
+                    type: string;
+                };
+                space: U64UnsafeBeyond2Pow53Minus1;
+            }>;
+        });
+    }
+
+    // `base58` with context
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { encoding: 'base58', withContext: true }).send();
+        result.context.slot satisfies bigint;
+        result.value.forEach(a => {
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base64`
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    // `base58` without context
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { encoding: 'base58' }).send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base64`
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    // `base58` without context (explicit)
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { encoding: 'base58', withContext: false }).send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base64`
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    // No encoding with context
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { withContext: true }).send();
+        result.context.slot satisfies bigint;
+        result.value.forEach(a => {
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58` data response
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    // No encoding without context
+    {
+        const result = await rpc.getProgramAccounts(programAddress).send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58` data response
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    // No encoding without context (explicit)
+    {
+        const result = await rpc.getProgramAccounts(programAddress, { withContext: false }).send();
+        assertNotAProperty(result, 'context');
+        result.forEach(a => {
+            a.account.data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58` data response
+            a.account.data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            a.account.data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            a.account.data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-transaction-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-transaction-typetest.ts
@@ -1,0 +1,80 @@
+import { Signature } from '@solana/keys';
+import { Base58EncodedDataResponse, Base64EncodedDataResponse, Commitment, Rpc } from '@solana/rpc-types';
+
+import { GetTransactionApi, TransactionJson, TransactionJsonParsed } from '../getTransaction';
+
+const rpc = null as unknown as Rpc<GetTransactionApi>;
+const signature = 'JoeSignature4444444444444444444444444444' as Signature;
+
+// Parameters
+const params = null as unknown as Parameters<GetTransactionApi['getTransaction']>[1];
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { encoding?: 'jsonParsed' | 'json' | 'base58' | 'base64' } | undefined;
+params satisfies { maxSupportedTransactionVersion?: 'legacy' | 0 } | undefined;
+
+async () => {
+    {
+        const result = await rpc.getTransaction(signature, { encoding: 'jsonParsed' }).send();
+        if (result) {
+            result.transaction satisfies TransactionJsonParsed;
+            // @ts-expect-error should not be `base58`
+            result.transaction satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            result.transaction satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `json`
+            result.transaction satisfies TransactionJson;
+        }
+    }
+
+    {
+        const result = await rpc.getTransaction(signature, { encoding: 'base64' }).send();
+        if (result) {
+            result.transaction satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58`
+            result.transaction satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `json`
+            result.transaction satisfies TransactionJson;
+            // @ts-expect-error should not be `jsonParsed`
+            result.transaction satisfies TransactionJsonParsed;
+        }
+    }
+
+    {
+        const result = await rpc.getTransaction(signature, { encoding: 'base58' }).send();
+        if (result) {
+            result.transaction satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            result.transaction satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `json`
+            result.transaction satisfies TransactionJson;
+            // @ts-expect-error should not be `jsonParsed`
+            result.transaction satisfies TransactionJsonParsed;
+        }
+    }
+
+    {
+        const result = await rpc.getTransaction(signature, { encoding: 'json' }).send();
+        if (result) {
+            result.transaction satisfies TransactionJson;
+            // @ts-expect-error should not be `base58`
+            result.transaction satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            result.transaction satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `jsonParsed`
+            result.transaction satisfies TransactionJsonParsed;
+        }
+    }
+
+    {
+        const result = await rpc.getTransaction(signature).send();
+        if (result) {
+            result.transaction satisfies TransactionJson;
+            // @ts-expect-error should not be `base58`
+            result.transaction satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            result.transaction satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `jsonParsed`
+            result.transaction satisfies TransactionJsonParsed;
+        }
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/getAccountInfo.ts
+++ b/packages/rpc-core/src/rpc-methods/getAccountInfo.ts
@@ -68,4 +68,20 @@ export interface GetAccountInfoApi extends IRpcApiMethods {
         address: Address,
         config?: GetAccountInfoApiCommonConfig,
     ): GetAccountInfoApiResponseBase & NestInRpcResponseOrNull<AccountInfoWithBase58Bytes>;
+    //
+    getAccountInfo(
+        address: Address,
+        config?: GetAccountInfoApiCommonConfig &
+            GetAccountInfoApiSliceableCommonConfig &
+            Readonly<{
+                encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
+            }>,
+    ): GetAccountInfoApiResponseBase &
+        NestInRpcResponseOrNull<
+            | AccountInfoWithBase58Bytes
+            | AccountInfoWithBase58EncodedData
+            | AccountInfoWithBase64EncodedData
+            | AccountInfoWithBase64EncodedZStdCompressedData
+            | AccountInfoWithJsonData
+        >;
 }

--- a/packages/rpc-core/src/rpc-methods/getBlock.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlock.ts
@@ -378,4 +378,28 @@ export interface GetBlockApi extends IRpcApiMethods {
               GetBlockApiResponseWithRewards &
               GetBlockApiResponseWithTransactions<TransactionForFullJson<void>>)
         | null;
+    //
+    getBlock(
+        slot: Slot,
+        config?: GetBlockCommonConfig &
+            Readonly<{
+                encoding?: GetBlockEncoding;
+                maxSupportedTransactionVersion?: GetBlockMaxSupportedTransactionVersion;
+                rewards?: boolean;
+                transactionDetails?: 'accounts' | 'full' | 'none' | 'signatures';
+            }>,
+    ):
+        | (GetBlockApiResponseBase &
+              Partial<GetBlockApiResponseWithRewards> &
+              Partial<GetBlockApiResponseWithSignatures> &
+              Partial<
+                  GetBlockApiResponseWithTransactions<
+                      | TransactionForAccounts<GetBlockMaxSupportedTransactionVersion | void>
+                      | TransactionForFullBase58<GetBlockMaxSupportedTransactionVersion | void>
+                      | TransactionForFullBase64<GetBlockMaxSupportedTransactionVersion | void>
+                      | TransactionForFullJsonParsed<GetBlockMaxSupportedTransactionVersion | void>
+                      | TransactionForFullJson<GetBlockMaxSupportedTransactionVersion | void>
+                  >
+              >)
+        | null;
 }

--- a/packages/rpc-core/src/rpc-methods/getProgramAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getProgramAccounts.ts
@@ -126,4 +126,30 @@ export interface GetProgramAccountsApi extends IRpcApiMethods {
                 withContext?: boolean;
             }>,
     ): AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58Bytes>[];
+    //
+    getProgramAccounts(
+        program: Address,
+        config?: GetProgramAccountsApiCommonConfig &
+            GetProgramAccountsApiSliceableCommonConfig &
+            Readonly<{
+                encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
+                withContext?: boolean;
+            }>,
+    ):
+        | (
+              | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58Bytes>
+              | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58EncodedData>
+              | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase64EncodedData>
+              | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase64EncodedZStdCompressedData>
+              | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithJsonData>
+          )[]
+        | RpcResponse<
+              (
+                  | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58Bytes>
+                  | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58EncodedData>
+                  | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase64EncodedData>
+                  | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase64EncodedZStdCompressedData>
+                  | AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithJsonData>
+              )[]
+          >;
 }

--- a/packages/rpc-core/src/rpc-methods/getTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/getTransaction.ts
@@ -75,7 +75,7 @@ type TransactionInstruction = Readonly<{
     data: Base58EncodedBytes;
 }>;
 
-type TransactionJson = TransactionBase &
+export type TransactionJson = TransactionBase &
     Readonly<{
         message: {
             accountKeys: readonly Address[];
@@ -103,7 +103,7 @@ type ParsedTransactionInstruction = Readonly<{
     programId: Address;
 }>;
 
-type TransactionJsonParsed = TransactionBase &
+export type TransactionJsonParsed = TransactionBase &
     Readonly<{
         message: {
             accountKeys: [
@@ -162,7 +162,7 @@ export interface GetTransactionApi extends IRpcApiMethods {
     /**
      * Returns transaction details for a confirmed transaction
      */
-    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | void = void>(
+    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | undefined = undefined>(
         signature: Signature,
         config: GetTransactionCommonConfig<TMaxSupportedTransactionVersion> &
             Readonly<{
@@ -170,17 +170,17 @@ export interface GetTransactionApi extends IRpcApiMethods {
             }>,
     ):
         | (GetTransactionApiResponseBase &
-              (TMaxSupportedTransactionVersion extends void
+              (TMaxSupportedTransactionVersion extends undefined
                   ? Record<string, never>
                   : { version: TransactionVersion }) & {
                   meta: (TransactionMetaBase & TransactionMetaInnerInstructionsParsed) | null;
                   transaction: TransactionJsonParsed &
-                      (TMaxSupportedTransactionVersion extends void
+                      (TMaxSupportedTransactionVersion extends undefined
                           ? Record<string, never>
                           : TransactionAddressTableLookups);
               })
         | null;
-    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | void = void>(
+    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | undefined = undefined>(
         signature: Signature,
         config: GetTransactionCommonConfig<TMaxSupportedTransactionVersion> &
             Readonly<{
@@ -188,20 +188,20 @@ export interface GetTransactionApi extends IRpcApiMethods {
             }>,
     ):
         | (GetTransactionApiResponseBase &
-              (TMaxSupportedTransactionVersion extends void
+              (TMaxSupportedTransactionVersion extends undefined
                   ? Record<string, never>
                   : { version: TransactionVersion }) & {
                   meta:
                       | (TransactionMetaBase &
                             TransactionMetaInnerInstructionsNotParsed &
-                            (TMaxSupportedTransactionVersion extends void
+                            (TMaxSupportedTransactionVersion extends undefined
                                 ? Record<string, never>
                                 : TransactionMetaLoadedAddresses))
                       | null;
                   transaction: Base64EncodedDataResponse;
               })
         | null;
-    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | void = void>(
+    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | undefined = undefined>(
         signature: Signature,
         config: GetTransactionCommonConfig<TMaxSupportedTransactionVersion> &
             Readonly<{
@@ -209,20 +209,20 @@ export interface GetTransactionApi extends IRpcApiMethods {
             }>,
     ):
         | (GetTransactionApiResponseBase &
-              (TMaxSupportedTransactionVersion extends void
+              (TMaxSupportedTransactionVersion extends undefined
                   ? Record<string, never>
                   : { version: TransactionVersion }) & {
                   meta:
                       | (TransactionMetaBase &
                             TransactionMetaInnerInstructionsNotParsed &
-                            (TMaxSupportedTransactionVersion extends void
+                            (TMaxSupportedTransactionVersion extends undefined
                                 ? Record<string, never>
                                 : TransactionMetaLoadedAddresses))
                       | null;
                   transaction: Base58EncodedDataResponse;
               })
         | null;
-    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | void = void>(
+    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | undefined = undefined>(
         signature: Signature,
         config?: GetTransactionCommonConfig<TMaxSupportedTransactionVersion> &
             Readonly<{
@@ -230,20 +230,42 @@ export interface GetTransactionApi extends IRpcApiMethods {
             }>,
     ):
         | (GetTransactionApiResponseBase &
-              (TMaxSupportedTransactionVersion extends void
+              (TMaxSupportedTransactionVersion extends undefined
                   ? Record<string, never>
                   : { version: TransactionVersion }) & {
                   meta:
                       | (TransactionMetaBase &
                             TransactionMetaInnerInstructionsNotParsed &
-                            (TMaxSupportedTransactionVersion extends void
+                            (TMaxSupportedTransactionVersion extends undefined
                                 ? Record<string, never>
                                 : TransactionMetaLoadedAddresses))
                       | null;
                   transaction: TransactionJson &
-                      (TMaxSupportedTransactionVersion extends void
+                      (TMaxSupportedTransactionVersion extends undefined
                           ? Record<string, never>
                           : TransactionAddressTableLookups);
+              })
+        | null;
+    //
+    getTransaction<TMaxSupportedTransactionVersion extends TransactionVersion | undefined = undefined>(
+        signature: Signature,
+        config?: GetTransactionCommonConfig<TMaxSupportedTransactionVersion> &
+            Readonly<{
+                encoding?: 'base58' | 'base64' | 'json' | 'jsonParsed';
+            }>,
+    ):
+        | (GetTransactionApiResponseBase &
+              Partial<{ version: TransactionVersion }> & {
+                  meta:
+                      | (TransactionMetaBase & TransactionMetaInnerInstructionsParsed)
+                      | (TransactionMetaBase &
+                            TransactionMetaInnerInstructionsNotParsed &
+                            Partial<TransactionMetaLoadedAddresses>)
+                      | null;
+                  transaction:
+                      | Base58EncodedDataResponse
+                      | Base64EncodedDataResponse
+                      | (TransactionJsonParsed & Partial<TransactionAddressTableLookups>);
               })
         | null;
 }

--- a/packages/rpc-graphql/src/loaders/block.ts
+++ b/packages/rpc-graphql/src/loaders/block.ts
@@ -23,7 +23,6 @@ function applyDefaultArgs({
 }
 
 async function loadBlock(rpc: Rpc<GetBlockApi>, { slot, ...config }: BlockLoaderArgs): Promise<BlockLoaderValue> {
-    // @ts-expect-error FIX ME: https://github.com/solana-labs/solana-web3.js/pull/2052
     return await rpc
         .getBlock(
             slot,

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -1,6 +1,6 @@
 import { Address } from '@solana/addresses';
 import { Signature } from '@solana/keys';
-import { GetAccountInfoApi, GetBlockApi, GetProgramAccountsApi, GetTransactionApi } from '@solana/rpc-core';
+import { GetAccountInfoApi, GetBlockApi, GetTransactionApi } from '@solana/rpc-core';
 import { Commitment, Slot } from '@solana/rpc-types';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
@@ -48,7 +48,10 @@ export type ProgramAccountsLoaderArgs = {
     minContextSlot?: Slot;
     programAddress: Address;
 };
-export type ProgramAccountsLoaderValue = ReturnType<GetProgramAccountsApi['getProgramAccounts']> | null;
+export type ProgramAccountsLoaderValue = {
+    pubkey: Address;
+    account: ReturnType<GetAccountInfoApi['getAccountInfo']>['value'];
+}[]; // TODO
 export type ProgramAccountsLoader = Loader<ProgramAccountsLoaderArgs, ProgramAccountsLoaderValue>;
 
 // FIX ME: https://github.com/solana-labs/solana-web3.js/pull/2052

--- a/packages/rpc-graphql/src/loaders/transaction.ts
+++ b/packages/rpc-graphql/src/loaders/transaction.ts
@@ -20,14 +20,7 @@ async function loadTransaction(
     rpc: Rpc<GetTransactionApi>,
     { signature, ...config }: TransactionLoaderArgs,
 ): Promise<TransactionLoaderValue> {
-    // @ts-expect-error FIX ME: https://github.com/solana-labs/solana-web3.js/pull/2052
-    return await rpc
-        .getTransaction(
-            signature,
-            // @ts-expect-error FIX ME: https://github.com/solana-labs/solana-web3.js/pull/2052
-            config,
-        )
-        .send();
+    return await rpc.getTransaction(signature, config).send();
 }
 
 function createTransactionBatchLoadFn(rpc: Rpc<GetTransactionApi>) {

--- a/packages/rpc-types/src/overloads.ts
+++ b/packages/rpc-types/src/overloads.ts
@@ -1,6 +1,6 @@
-export type Overloads<T> = Overloads24<T>;
-type Overloads24<T> =
-    // Have an RPC method with more than 24 overloads? Add another section and update this comment
+export type Overloads<T> = Overloads25<T>;
+type Overloads25<T> =
+    // Have an RPC method with more than 25 overloads? Add another section and update this comment
     T extends {
         (...args: infer A1): infer R1;
         (...args: infer A2): infer R2;
@@ -26,6 +26,7 @@ type Overloads24<T> =
         (...args: infer A22): infer R22;
         (...args: infer A23): infer R23;
         (...args: infer A24): infer R24;
+        (...args: infer A25): infer R25;
     }
         ? [
               (...args: A1) => R1,
@@ -52,8 +53,62 @@ type Overloads24<T> =
               (...args: A22) => R22,
               (...args: A23) => R23,
               (...args: A24) => R24,
+              (...args: A25) => R25,
           ]
-        : Overloads23<T>;
+        : Overloads24<T>;
+type Overloads24<T> = T extends {
+    (...args: infer A1): infer R1;
+    (...args: infer A2): infer R2;
+    (...args: infer A3): infer R3;
+    (...args: infer A4): infer R4;
+    (...args: infer A5): infer R5;
+    (...args: infer A6): infer R6;
+    (...args: infer A7): infer R7;
+    (...args: infer A8): infer R8;
+    (...args: infer A9): infer R9;
+    (...args: infer A10): infer R10;
+    (...args: infer A11): infer R11;
+    (...args: infer A12): infer R12;
+    (...args: infer A13): infer R13;
+    (...args: infer A14): infer R14;
+    (...args: infer A15): infer R15;
+    (...args: infer A16): infer R16;
+    (...args: infer A17): infer R17;
+    (...args: infer A18): infer R18;
+    (...args: infer A19): infer R19;
+    (...args: infer A20): infer R20;
+    (...args: infer A21): infer R21;
+    (...args: infer A22): infer R22;
+    (...args: infer A23): infer R23;
+    (...args: infer A24): infer R24;
+}
+    ? [
+          (...args: A1) => R1,
+          (...args: A2) => R2,
+          (...args: A3) => R3,
+          (...args: A4) => R4,
+          (...args: A5) => R5,
+          (...args: A6) => R6,
+          (...args: A7) => R7,
+          (...args: A8) => R8,
+          (...args: A9) => R9,
+          (...args: A10) => R10,
+          (...args: A11) => R11,
+          (...args: A12) => R12,
+          (...args: A13) => R13,
+          (...args: A14) => R14,
+          (...args: A15) => R15,
+          (...args: A16) => R16,
+          (...args: A17) => R17,
+          (...args: A18) => R18,
+          (...args: A19) => R19,
+          (...args: A20) => R20,
+          (...args: A21) => R21,
+          (...args: A22) => R22,
+          (...args: A23) => R23,
+          (...args: A24) => R24,
+      ]
+    : Overloads23<T>;
 type Overloads23<T> = T extends {
     (...args: infer A1): infer R1;
     (...args: infer A2): infer R2;


### PR DESCRIPTION
Our RPC API is very difficult to use when attempting to define types and/or use
IntelliSense on the parameters of any of the defined methods.

As an example, I've defined a type that uses
`Parameters<GetAccountInfoApi['getAccountInfo']` and you can see that in my
first attempt - without making any changes to the library - the type inferred
from that declaration is missing a few fields, particularly `encoding` and
`dataSlice`.

<img width="612" alt="Screenshot 2024-01-19 at 12 04 52 PM" src="https://github.com/solana-labs/solana-web3.js/assets/67205063/fb9cbcdc-01fc-4082-88d2-04d53d922efa">

Because of the way our overloads are structured, TypeScript can't seem to
understand all possible variations of the arguments. Instead, it just takes the
last overload as the type.

This change proposes we add a master union function declaration at the end of
every RPC Core API method, so that IntelliSense and TypeScript can interpret the
full union for parameters or return types.

<img width="602" alt="Screenshot 2024-01-19 at 12 06 06 PM" src="https://github.com/solana-labs/solana-web3.js/assets/67205063/bec8edd5-2eda-400a-a636-d242f1593a41">

Edit: After further review, this change in fact does preserve type inference based on inputs for all API interfaces. However, `sendTransaction` and `simulateTransaction` (later in this stack), as well as any other overloads that are non-exhaustive, will need special handling. The rest are good to go.