### PR TITLE
refactor(experimental): move transport types out of rpc-transport

### DIFF
--- a/packages/library/src/__tests__/rpc-integer-overflow-test.ts
+++ b/packages/library/src/__tests__/rpc-integer-overflow-test.ts
@@ -1,4 +1,4 @@
-import type { IRpcTransport } from '@solana/rpc-transport';
+import type { IRpcTransport } from '@solana/rpc-types';
 
 import { createSolanaRpc } from '../rpc';
 import { SolanaJsonRpcIntegerOverflowError } from '../rpc-integer-overflow-error';

--- a/packages/library/src/__tests__/rpc-request-coalescer-test.ts
+++ b/packages/library/src/__tests__/rpc-request-coalescer-test.ts
@@ -1,4 +1,4 @@
-import type { IRpcTransport } from '@solana/rpc-transport';
+import type { IRpcTransport } from '@solana/rpc-types';
 
 import { getRpcTransportWithRequestCoalescing } from '../rpc-request-coalescer';
 

--- a/packages/library/src/rpc-request-coalescer.ts
+++ b/packages/library/src/rpc-request-coalescer.ts
@@ -1,4 +1,4 @@
-import type { IRpcTransport } from '@solana/rpc-transport';
+import type { IRpcTransport } from '@solana/rpc-types';
 
 type CoalescedRequest = {
     readonly abortController: AbortController;

--- a/packages/library/src/rpc-transport.ts
+++ b/packages/library/src/rpc-transport.ts
@@ -1,5 +1,6 @@
 import { pipe } from '@solana/functional';
-import { createHttpTransport, type IRpcTransport } from '@solana/rpc-transport';
+import { createHttpTransport } from '@solana/rpc-transport';
+import type { IRpcTransport } from '@solana/rpc-types';
 
 import { getRpcTransportWithRequestCoalescing } from './rpc-request-coalescer';
 import { getSolanaRpcPayloadDeduplicationKey } from './rpc-request-deduplication';

--- a/packages/rpc-transport/src/__tests__/json-rpc-test.ts
+++ b/packages/rpc-transport/src/__tests__/json-rpc-test.ts
@@ -1,10 +1,9 @@
-import { IRpcApi, Rpc, RpcRequest } from '@solana/rpc-types';
+import { IRpcApi, IRpcTransport, Rpc, RpcRequest } from '@solana/rpc-types';
 
 import { createJsonRpc } from '../json-rpc';
 import { SolanaJsonRpcError } from '../json-rpc-errors';
 import { createJsonRpcMessage } from '../json-rpc-message';
 import { getNextMessageId } from '../json-rpc-message-id';
-import { IRpcTransport } from '../transports/transport-types';
 
 jest.mock('../json-rpc-message-id');
 

--- a/packages/rpc-transport/src/index.ts
+++ b/packages/rpc-transport/src/index.ts
@@ -6,5 +6,5 @@ export type { SolanaJsonRpcErrorCode } from './json-rpc-errors';
 export * from './json-rpc-subscription';
 
 export * from './transports/http/http-transport';
-export type { IRpcTransport, IRpcWebSocketTransport } from './transports/transport-types';
+export type { IRpcWebSocketTransport } from './transports/transport-types';
 export * from './transports/websocket/websocket-transport';

--- a/packages/rpc-transport/src/json-rpc-config.ts
+++ b/packages/rpc-transport/src/json-rpc-config.ts
@@ -1,6 +1,6 @@
-import { IRpcApi, IRpcSubscriptionsApi } from '@solana/rpc-types';
+import { IRpcApi, IRpcSubscriptionsApi, IRpcTransport } from '@solana/rpc-types';
 
-import { IRpcTransport, IRpcWebSocketTransport } from './transports/transport-types';
+import { IRpcWebSocketTransport } from './transports/transport-types';
 
 export type RpcConfig<TRpcMethods> = Readonly<{
     api: IRpcApi<TRpcMethods>;

--- a/packages/rpc-transport/src/transports/http/__tests__/http-transport-abort-test.ts
+++ b/packages/rpc-transport/src/transports/http/__tests__/http-transport-abort-test.ts
@@ -1,6 +1,6 @@
+import { IRpcTransport } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { IRpcTransport } from '../../transport-types';
 import { createHttpTransport } from '../http-transport';
 
 describe('createHttpTransport and `AbortSignal`', () => {

--- a/packages/rpc-transport/src/transports/http/__tests__/http-transport-headers-test.ts
+++ b/packages/rpc-transport/src/transports/http/__tests__/http-transport-headers-test.ts
@@ -1,4 +1,5 @@
-import { IRpcTransport } from '../../transport-types';
+import { IRpcTransport } from '@solana/rpc-types';
+
 import { createHttpTransport } from '../http-transport';
 import { assertIsAllowedHttpRequestHeaders } from '../http-transport-headers';
 

--- a/packages/rpc-transport/src/transports/http/__tests__/http-transport-test.ts
+++ b/packages/rpc-transport/src/transports/http/__tests__/http-transport-test.ts
@@ -1,6 +1,6 @@
+import { IRpcTransport } from '@solana/rpc-types';
 import fetchMock from 'jest-fetch-mock-fork';
 
-import { IRpcTransport } from '../../transport-types';
 import { createHttpTransport } from '../http-transport';
 import { SolanaHttpError } from '../http-transport-errors';
 

--- a/packages/rpc-transport/src/transports/http/http-transport.ts
+++ b/packages/rpc-transport/src/transports/http/http-transport.ts
@@ -1,6 +1,6 @@
+import { IRpcTransport } from '@solana/rpc-types';
 import fetchImpl from 'fetch-impl';
 
-import { IRpcTransport } from '../transport-types';
 import { SolanaHttpError } from './http-transport-errors';
 import {
     AllowedHttpRequestHeaders,

--- a/packages/rpc-transport/src/transports/transport-types.ts
+++ b/packages/rpc-transport/src/transports/transport-types.ts
@@ -1,14 +1,5 @@
 import { RpcWebSocketConnection } from './websocket/websocket-connection';
 
-type RpcTransportConfig = Readonly<{
-    payload: unknown;
-    signal?: AbortSignal;
-}>;
-
-export interface IRpcTransport {
-    <TResponse>(config: RpcTransportConfig): Promise<TResponse>;
-}
-
 type RpcWebSocketTransportConfig = Readonly<{
     payload: unknown;
     signal: AbortSignal;

--- a/packages/rpc-types/src/rpc-api.ts
+++ b/packages/rpc-types/src/rpc-api.ts
@@ -1,6 +1,18 @@
 import type { Overloads } from './overloads';
 import type { Slot } from './typed-numbers';
 
+type RpcTransportConfig = Readonly<{
+    payload: unknown;
+    signal?: AbortSignal;
+}>;
+
+/**
+ * Public RPC Transport API
+ */
+export interface IRpcTransport {
+    <TResponse>(config: RpcTransportConfig): Promise<TResponse>;
+}
+
 /**
  * Public RPC API.
  */


### PR DESCRIPTION
Slides the RPC Transport types into `@solana/rpc-types`.