### PR TITLE
refactor(experimental): rpc-core: add master union types to API definition part 2

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
+++ b/packages/rpc-core/src/rpc-methods/__tests__/get-leader-schedule-test.ts
@@ -46,7 +46,7 @@ describe('getLeaderSchedule', () => {
             describe('when called with no identity and no slot', () => {
                 it('returns the leader schedule for all cluster nodes in the current epoch', async () => {
                     expect.assertions(3);
-                    const res = await rpc.getLeaderSchedule({ commitment }).send();
+                    const res = await rpc.getLeaderSchedule(null, { commitment }).send();
                     // Does not need null check (default slot)
                     expect(res).toStrictEqual(expect.any(Object));
                     for (const key of Object.keys(res)) {
@@ -79,7 +79,7 @@ describe('getLeaderSchedule', () => {
                     expect.assertions(1);
                     const identity = await getValidatorAddress();
                     const res = await rpc
-                        .getLeaderSchedule({
+                        .getLeaderSchedule(null, {
                             commitment,
                             identity,
                         })
@@ -114,7 +114,7 @@ describe('getLeaderSchedule', () => {
             it('returns an empty object', async () => {
                 expect.assertions(1);
                 const res = await rpc
-                    .getLeaderSchedule({
+                    .getLeaderSchedule(null, {
                         commitment,
                         // See scripts/fixtures/GQE2yjns7SKKuMc89tveBDpzYHwXfeuB2PGAbGaPWc6G.json
                         identity: 'GQE2yjns7SKKuMc89tveBDpzYHwXfeuB2PGAbGaPWc6G' as Address,
@@ -128,7 +128,7 @@ describe('getLeaderSchedule', () => {
             it('returns an empty object', async () => {
                 expect.assertions(1);
                 const res = await rpc
-                    .getLeaderSchedule({
+                    .getLeaderSchedule(null, {
                         commitment,
                         // Randomly generated
                         identity: 'BnWCFuxmi6uH3ceVx4R8qcbWBMPVVYVVFWtAiiTA1PAu' as Address,

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-block-production-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-block-production-typetest.ts
@@ -1,0 +1,33 @@
+import { Address } from '@solana/addresses';
+import { Commitment, Rpc, Slot } from '@solana/rpc-types';
+
+import { GetBlockProductionApi } from '../getBlockProduction';
+
+const rpc = null as unknown as Rpc<GetBlockProductionApi>;
+const identity = 'Joe11111111111111111111111111111' as Address<'Joe11111111111111111111111111111'>;
+
+// Parameters
+const params = null as unknown as Parameters<GetBlockProductionApi['getBlockProduction']>[0];
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { range?: { firstSlot: Slot; lastSlot: Slot } } | undefined;
+params satisfies { identity?: Address } | undefined;
+
+async () => {
+    {
+        const result = await rpc.getBlockProduction().send();
+        if (result.value) {
+            const { range, byIdentity } = result.value;
+            range satisfies { firstSlot: Slot; lastSlot: Slot };
+            byIdentity satisfies Record<Address, [bigint, bigint]>;
+        }
+    }
+
+    {
+        const result = await rpc.getBlockProduction({ identity }).send();
+        if (result.value) {
+            const { range, byIdentity } = result.value;
+            range satisfies { firstSlot: Slot; lastSlot: Slot };
+            byIdentity satisfies Readonly<{ [x: Address]: [bigint, bigint] | undefined }>;
+        }
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-leader-schedule-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-leader-schedule-typetest.ts
@@ -1,0 +1,39 @@
+import { Address } from '@solana/addresses';
+import { Commitment, Rpc, Slot } from '@solana/rpc-types';
+
+import { GetLeaderScheduleApi } from '../getLeaderSchedule';
+
+const rpc = null as unknown as Rpc<GetLeaderScheduleApi>;
+const slot = 0n as Slot;
+const identity = 'Joe11111111111111111111111111111' as Address<'Joe11111111111111111111111111111'>;
+
+// Parameters
+const params = null as unknown as Parameters<GetLeaderScheduleApi['getLeaderSchedule']>[1];
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { identity?: Address } | undefined;
+
+async () => {
+    {
+        const result = await rpc.getLeaderSchedule(slot).send();
+        // Can be null if the slot corresponds to an epoch that does not exist
+        result satisfies Record<Address, Slot[]> | null;
+    }
+
+    {
+        const result = await rpc.getLeaderSchedule(null).send();
+        // Won't be null
+        result satisfies Record<Address, Slot[]>;
+    }
+
+    {
+        const result = await rpc.getLeaderSchedule(slot, { identity }).send();
+        // Can be null if the slot corresponds to an epoch that does not exist
+        result satisfies Readonly<{ [key: Address]: Slot[] | undefined }> | null;
+    }
+
+    {
+        const result = await rpc.getLeaderSchedule(null, { identity }).send();
+        // Won't be null
+        result satisfies Readonly<{ [key: Address]: Slot[] | undefined }>;
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-multiple-accounts-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-multiple-accounts-typetest.ts
@@ -1,0 +1,124 @@
+import { Address } from '@solana/addresses';
+import {
+    Base58EncodedBytes,
+    Base58EncodedDataResponse,
+    Base64EncodedDataResponse,
+    Base64EncodedZStdCompressedDataResponse,
+    Commitment,
+    Rpc,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
+
+import { GetMultipleAccountsApi } from '../getMultipleAccounts';
+
+const rpc = null as unknown as Rpc<GetMultipleAccountsApi>;
+const address = 'Joe11111111111111111111111111111' as Address<'Joe11111111111111111111111111111'>;
+
+// Parameters
+const params = null as unknown as Parameters<GetMultipleAccountsApi['getMultipleAccounts']>[1];
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { dataSlice?: { length: number; offset: number } } | undefined;
+params satisfies { encoding?: 'jsonParsed' | 'base58' | 'base64' | 'base64+zstd' } | undefined;
+params satisfies { minContextSlot?: bigint } | undefined;
+
+async () => {
+    {
+        const result = await rpc.getMultipleAccounts([address], { encoding: 'base64' }).send();
+        result.value.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58`
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+            }
+        });
+    }
+
+    {
+        const result = await rpc.getMultipleAccounts([address], { encoding: 'base64+zstd' }).send();
+        result.value.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58`
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64`
+                data satisfies Base64EncodedDataResponse;
+            }
+        });
+    }
+
+    {
+        const result = await rpc.getMultipleAccounts([address], { encoding: 'jsonParsed' }).send();
+        result.value.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies
+                    | Readonly<{
+                          program: string;
+                          parsed: {
+                              info?: object;
+                              type: string;
+                          };
+                          space: U64UnsafeBeyond2Pow53Minus1;
+                      }>
+                    | Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58`
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+                // @ts-expect-error should not be `base64` on its own
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `jsonParsed` on its own
+                data satisfies Readonly<{
+                    program: string;
+                    parsed: {
+                        info?: object;
+                        type: string;
+                    };
+                    space: U64UnsafeBeyond2Pow53Minus1;
+                }>;
+            }
+        });
+    }
+
+    {
+        const result = await rpc.getMultipleAccounts([address], { encoding: 'base58' }).send();
+        result.value.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base64`
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+            }
+        });
+    }
+
+    {
+        const result = await rpc.getMultipleAccounts([address]).send();
+        result.value.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58` data response
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+            }
+        });
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-slot-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-slot-typetest.ts
@@ -1,0 +1,52 @@
+import { Address } from '@solana/addresses';
+import { Commitment, Rpc } from '@solana/rpc-types';
+
+import { GetSupplyApi } from '../getSupply';
+
+const rpc = null as unknown as Rpc<GetSupplyApi>;
+
+// Parameters
+const params = null as unknown as Parameters<GetSupplyApi['getSupply']>[0];
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { excludeNonCirculatingAccountsList?: boolean } | undefined;
+
+async () => {
+    {
+        const result = await rpc.getSupply({ excludeNonCirculatingAccountsList: true }).send();
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: never[];
+            }>;
+        }>;
+    }
+
+    {
+        const result = await rpc.getSupply().send();
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: Address[];
+            }>;
+        }>;
+        // @ts-expect-error should not be `never`
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: never[];
+            }>;
+        }>;
+    }
+
+    {
+        const result = await rpc.getSupply({ excludeNonCirculatingAccountsList: false }).send();
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: Address[];
+            }>;
+        }>;
+        // @ts-expect-error should not be `never`
+        result satisfies Readonly<{
+            value: Readonly<{
+                nonCirculatingAccounts: never[];
+            }>;
+        }>;
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-token-accounts-by-delegate-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-token-accounts-by-delegate-typetest.ts
@@ -1,0 +1,106 @@
+import { Address } from '@solana/addresses';
+import {
+    Base58EncodedBytes,
+    Base58EncodedDataResponse,
+    Base64EncodedDataResponse,
+    Base64EncodedZStdCompressedDataResponse,
+    Commitment,
+    Rpc,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
+
+import { GetTokenAccountsByDelegateApi } from '../getTokenAccountsByDelegate';
+
+const rpc = null as unknown as Rpc<GetTokenAccountsByDelegateApi>;
+const address = 'Joe11111111111111111111111111111' as Address<'Joe11111111111111111111111111111'>;
+const filter = {
+    mint: 'Mint1111111111111111111111111111' as Address<'Mint1111111111111111111111111111'>,
+};
+
+// Parameters
+const params = null as unknown as Parameters<GetTokenAccountsByDelegateApi['getTokenAccountsByDelegate']>[2];
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { dataSlice?: { length: number; offset: number } } | undefined;
+params satisfies { encoding?: 'jsonParsed' | 'base58' | 'base64' | 'base64+zstd' } | undefined;
+params satisfies { minContextSlot?: bigint } | undefined;
+
+async () => {
+    {
+        const result = await rpc.getTokenAccountsByDelegate(address, filter, { encoding: 'base64' }).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    {
+        const result = await rpc.getTokenAccountsByDelegate(address, filter, { encoding: 'base64+zstd' }).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+        });
+    }
+
+    {
+        const result = await rpc.getTokenAccountsByDelegate(address, filter, { encoding: 'jsonParsed' }).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Readonly<{
+                program: string;
+                parsed: {
+                    info?: object;
+                    type: string;
+                };
+                space: U64UnsafeBeyond2Pow53Minus1;
+            }>;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    {
+        const result = await rpc.getTokenAccountsByDelegate(address, filter, { encoding: 'base58' }).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    {
+        const result = await rpc.getTokenAccountsByDelegate(address, filter).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` data response
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/__typetests__/get-token-accounts-by-owner-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/get-token-accounts-by-owner-typetest.ts
@@ -1,0 +1,106 @@
+import { Address } from '@solana/addresses';
+import {
+    Base58EncodedBytes,
+    Base58EncodedDataResponse,
+    Base64EncodedDataResponse,
+    Base64EncodedZStdCompressedDataResponse,
+    Commitment,
+    Rpc,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
+
+import { GetTokenAccountsByOwnerApi } from '../getTokenAccountsByOwner';
+
+const rpc = null as unknown as Rpc<GetTokenAccountsByOwnerApi>;
+const address = 'Joe11111111111111111111111111111' as Address<'Joe11111111111111111111111111111'>;
+const filter = {
+    mint: 'Mint1111111111111111111111111111' as Address<'Mint1111111111111111111111111111'>,
+};
+
+// Parameters
+const params = null as unknown as Parameters<GetTokenAccountsByOwnerApi['getTokenAccountsByOwner']>[2];
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { dataSlice?: { length: number; offset: number } } | undefined;
+params satisfies { encoding?: 'jsonParsed' | 'base58' | 'base64' | 'base64+zstd' } | undefined;
+params satisfies { minContextSlot?: bigint } | undefined;
+
+async () => {
+    {
+        const result = await rpc.getTokenAccountsByOwner(address, filter, { encoding: 'base64' }).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    {
+        const result = await rpc.getTokenAccountsByOwner(address, filter, { encoding: 'base64+zstd' }).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+        });
+    }
+
+    {
+        const result = await rpc.getTokenAccountsByOwner(address, filter, { encoding: 'jsonParsed' }).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Readonly<{
+                program: string;
+                parsed: {
+                    info?: object;
+                    type: string;
+                };
+                space: U64UnsafeBeyond2Pow53Minus1;
+            }>;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base58`
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    {
+        const result = await rpc.getTokenAccountsByOwner(address, filter, { encoding: 'base58' }).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base58` bytes
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+
+    {
+        const result = await rpc.getTokenAccountsByOwner(address, filter).send();
+        result.value.forEach(({ account }) => {
+            const { data } = account;
+            data satisfies Base58EncodedBytes;
+            // @ts-expect-error should not be `base64`
+            data satisfies Base64EncodedDataResponse;
+            // @ts-expect-error should not be `base58` data response
+            data satisfies Base58EncodedDataResponse;
+            // @ts-expect-error should not be `base64+zstd`
+            data satisfies Base64EncodedZStdCompressedDataResponse;
+        });
+    }
+};

--- a/packages/rpc-core/src/rpc-methods/getBlockProduction.ts
+++ b/packages/rpc-core/src/rpc-methods/getBlockProduction.ts
@@ -43,4 +43,12 @@ export interface GetBlockProductionApi extends IRpcApiMethods {
     getBlockProduction(
         config?: GetBlockProductionApiConfigBase,
     ): GetBlockProductionApiResponseBase & GetBlockProductionApiResponseWithAllIdentities;
+    //
+    getBlockProduction<TIdentity extends Address>(
+        config?: GetBlockProductionApiConfigBase &
+            Readonly<{
+                identity?: TIdentity;
+            }>,
+    ): GetBlockProductionApiResponseBase &
+        (GetBlockProductionApiResponseWithAllIdentities | GetBlockProductionApiResponseWithSingleIdentity<TIdentity>);
 }

--- a/packages/rpc-core/src/rpc-methods/getLeaderSchedule.ts
+++ b/packages/rpc-core/src/rpc-methods/getLeaderSchedule.ts
@@ -1,6 +1,10 @@
 import type { Address } from '@solana/addresses';
 import type { Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
 
+type GetLeaderScheduleApiConfigBase = Readonly<{
+    commitment?: Commitment;
+}>;
+
 /**
  * This return type is a dictionary of validator identities, as base-58 encoded
  * strings, and their corresponding leader slot indices as values
@@ -17,8 +21,10 @@ import type { Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
  * }
  * ```
  */
-type GetLeaderScheduleApiResponseBase = Readonly<{
-    [key: Address]: Slot[];
+type GetLeaderScheduleApiResponseWithAllIdentities = Record<Address, Slot[]>;
+
+type GetLeaderScheduleApiResponseWithSingleIdentity<TIdentity extends string> = Readonly<{
+    [TAddress in TIdentity]?: Slot[];
 }>;
 
 export interface GetLeaderScheduleApi extends IRpcApiMethods {
@@ -28,21 +34,42 @@ export interface GetLeaderScheduleApi extends IRpcApiMethods {
      *
      * When a slot is provided, the leader schedule for the epoch that corresponds
      * to the provided slot is returned, and this can be null if the slot corresponds
-     * to an epoch that does not exist
+     * to an epoch that does not exist.
+     *
+     * The RPC request payload provides a `null` value for `slot` when the slot is not
+     * specified but the request wishes to include config.
      */
+    getLeaderSchedule<TIdentity extends Address>(
+        slot: Slot,
+        config: GetLeaderScheduleApiConfigBase &
+            Readonly<{
+                /** Only return results for this validator identity (base58 encoded address) */
+                identity: Address;
+            }>,
+    ): GetLeaderScheduleApiResponseWithSingleIdentity<TIdentity> | null;
     getLeaderSchedule(
         slot: Slot,
-        config?: Readonly<{
-            commitment?: Commitment;
-            /** Only return results for this validator identity (base58 encoded address) */
-            identity?: Address;
-        }>,
-    ): GetLeaderScheduleApiResponseBase | null;
+        config?: GetLeaderScheduleApiConfigBase,
+    ): GetLeaderScheduleApiResponseWithAllIdentities | null;
+    getLeaderSchedule<TIdentity extends Address>(
+        slot: null,
+        config: GetLeaderScheduleApiConfigBase &
+            Readonly<{
+                /** Only return results for this validator identity (base58 encoded address) */
+                identity: Address;
+            }>,
+    ): GetLeaderScheduleApiResponseWithSingleIdentity<TIdentity>;
     getLeaderSchedule(
-        config?: Readonly<{
-            commitment?: Commitment;
-            /** Only return results for this validator identity (base58 encoded address) */
-            identity?: Address;
-        }>,
-    ): GetLeaderScheduleApiResponseBase;
+        slot: null,
+        config?: GetLeaderScheduleApiConfigBase,
+    ): GetLeaderScheduleApiResponseWithAllIdentities;
+    //
+    getLeaderSchedule<TIdentity extends Address>(
+        slot: Slot | null,
+        config?: GetLeaderScheduleApiConfigBase &
+            Readonly<{
+                /** Only return results for this validator identity (base58 encoded address) */
+                identity?: Address;
+            }>,
+    ): GetLeaderScheduleApiResponseWithAllIdentities | GetLeaderScheduleApiResponseWithSingleIdentity<TIdentity> | null;
 }

--- a/packages/rpc-core/src/rpc-methods/getMultipleAccounts.ts
+++ b/packages/rpc-core/src/rpc-methods/getMultipleAccounts.ts
@@ -68,4 +68,22 @@ export interface GetMultipleAccountsApi extends IRpcApiMethods {
         addresses: Address[],
         config?: GetMultipleAccountsApiCommonConfig,
     ): RpcResponse<(GetMultipleAccountsApiResponseBase & (AccountInfoWithBase64EncodedData | null))[]>;
+    //
+    getMultipleAccounts(
+        addresses: Address[],
+        config?: GetMultipleAccountsApiCommonConfig &
+            GetMultipleAccountsApiSliceableCommonConfig &
+            Readonly<{
+                encoding: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed';
+            }>,
+    ): RpcResponse<
+        (GetMultipleAccountsApiResponseBase &
+            (
+                | AccountInfoWithBase58EncodedData
+                | AccountInfoWithBase64EncodedData
+                | AccountInfoWithBase64EncodedZStdCompressedData
+                | AccountInfoWithJsonData
+                | null
+            ))[]
+    >;
 }

--- a/packages/rpc-core/src/rpc-methods/getSupply.ts
+++ b/packages/rpc-core/src/rpc-methods/getSupply.ts
@@ -3,7 +3,6 @@ import type { Commitment, IRpcApiMethods, LamportsUnsafeBeyond2Pow53Minus1, RpcR
 
 type GetSupplyConfig = Readonly<{
     commitment?: Commitment;
-    excludeNonCirculatingAccountsList?: boolean;
 }>;
 
 type GetSupplyApiResponseBase = RpcResponse<{
@@ -19,14 +18,18 @@ type GetSupplyApiResponseWithNonCirculatingAccounts = GetSupplyApiResponseBase &
     Readonly<{
         value: Readonly<{
             /** an array of account addresses of non-circulating accounts */
-            nonCirculatingAccounts: [Address];
+            nonCirculatingAccounts: Address[];
         }>;
     }>;
 
 type GetSupplyApiResponseWithoutNonCirculatingAccounts = GetSupplyApiResponseBase &
     Readonly<{
         value: Readonly<{
-            nonCirculatingAccounts: [];
+            /** As per the docs:
+             * "If `excludeNonCirculatingAccountsList` is enabled, the returned array will be empty."
+             * See: https://solana.com/docs/rpc/http/getsupply
+             */
+            nonCirculatingAccounts: never[];
         }>;
     }>;
 
@@ -40,5 +43,17 @@ export interface GetSupplyApi extends IRpcApiMethods {
                 excludeNonCirculatingAccountsList: true;
             }>,
     ): GetSupplyApiResponseWithoutNonCirculatingAccounts;
-    getSupply(config?: GetSupplyConfig): GetSupplyApiResponseWithNonCirculatingAccounts;
+    getSupply(
+        config?: GetSupplyConfig &
+            Readonly<{
+                excludeNonCirculatingAccountsList?: false;
+            }>,
+    ): GetSupplyApiResponseWithNonCirculatingAccounts;
+    //
+    getSupply(
+        config?: GetSupplyConfig &
+            Readonly<{
+                excludeNonCirculatingAccountsList?: boolean;
+            }>,
+    ): GetSupplyApiResponseWithNonCirculatingAccounts | GetSupplyApiResponseWithoutNonCirculatingAccounts;
 }

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountsByDelegate.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountsByDelegate.ts
@@ -95,4 +95,23 @@ export interface GetTokenAccountsByDelegateApi extends IRpcApiMethods {
         filter: AccountsFilter,
         config?: GetTokenAccountsByDelegateApiCommonConfig & GetTokenAccountsByDelegateApiSliceableCommonConfig,
     ): RpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58Bytes>[]>;
+    //
+    getTokenAccountsByDelegate(
+        program: Address,
+        filter: AccountsFilter,
+        config?: GetTokenAccountsByDelegateApiCommonConfig &
+            GetTokenAccountsByDelegateApiSliceableCommonConfig &
+            Readonly<{ encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed' }>,
+    ): RpcResponse<
+        AccountInfoWithPubkey<
+            AccountInfoBase &
+                (
+                    | AccountInfoWithBase58Bytes
+                    | AccountInfoWithBase58EncodedData
+                    | AccountInfoWithBase64EncodedData
+                    | AccountInfoWithBase64EncodedZStdCompressedData
+                    | TokenAccountInfoWithJsonData
+                )
+        >[]
+    >;
 }

--- a/packages/rpc-core/src/rpc-methods/getTokenAccountsByOwner.ts
+++ b/packages/rpc-core/src/rpc-methods/getTokenAccountsByOwner.ts
@@ -95,4 +95,23 @@ export interface GetTokenAccountsByOwnerApi extends IRpcApiMethods {
         filter: AccountsFilter,
         config?: GetTokenAccountsByOwnerApiCommonConfig & GetTokenAccountsByOwnerApiSliceableCommonConfig,
     ): RpcResponse<AccountInfoWithPubkey<AccountInfoBase & AccountInfoWithBase58Bytes>[]>;
+    //
+    getTokenAccountsByOwner(
+        program: Address,
+        filter: AccountsFilter,
+        config?: GetTokenAccountsByOwnerApiCommonConfig &
+            GetTokenAccountsByOwnerApiSliceableCommonConfig &
+            Readonly<{ encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed' }>,
+    ): RpcResponse<
+        AccountInfoWithPubkey<
+            AccountInfoBase &
+                (
+                    | AccountInfoWithBase58Bytes
+                    | AccountInfoWithBase58EncodedData
+                    | AccountInfoWithBase64EncodedData
+                    | AccountInfoWithBase64EncodedZStdCompressedData
+                    | TokenAccountInfoWithJsonData
+                )
+        >[]
+    >;
 }


### PR DESCRIPTION
Continuing the work from the previous commit in the stack to add union overloads
to the RPC methods, so we can get better type inference on things like
`Parameters<T>`.

In this commit I've caught a few mistakes in the RPC methods themselves, as
well.
