### PR TITLE
refactor(experimental): rpc-core: add master union types to API definition part 3

### DIFF
--- a/packages/rpc-core/src/rpc-methods/__typetests__/send-transaction-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/send-transaction-typetest.ts
@@ -1,0 +1,32 @@
+import { Signature } from '@solana/keys';
+import { Base58EncodedBytes, Commitment, Rpc, Slot } from '@solana/rpc-types';
+import { Base64EncodedWireTransaction } from '@solana/transactions';
+
+import { SendTransactionApi } from '../sendTransaction';
+
+const rpc = null as unknown as Rpc<SendTransactionApi>;
+const transactionBase58 = null as unknown as Base58EncodedBytes;
+const transactionBase64 = null as unknown as Base64EncodedWireTransaction;
+
+// Parameters
+const params = null as unknown as Parameters<SendTransactionApi['sendTransaction']>[1];
+params satisfies { encoding?: 'base58' | 'base64' } | undefined;
+params satisfies { maxRetries?: bigint } | undefined;
+params satisfies { minContextSlot?: Slot } | undefined;
+params satisfies { preflightCommitment?: Commitment } | undefined;
+params satisfies { skipPreflight?: boolean } | undefined;
+
+async () => {
+    {
+        const result = await rpc.sendTransaction(transactionBase58, { encoding: 'base58' }).send();
+        result satisfies Signature;
+    }
+    {
+        const result = await rpc.sendTransaction(transactionBase64, { encoding: 'base64' }).send();
+        result satisfies Signature;
+    }
+    // @ts-expect-error can't mix encodings
+    rpc.sendTransaction(transactionBase58, { encoding: 'base64' });
+    // @ts-expect-error can't mix encodings
+    rpc.sendTransaction(transactionBase64, { encoding: 'base58' });
+};

--- a/packages/rpc-core/src/rpc-methods/__typetests__/simulate-transaction-typetest.ts
+++ b/packages/rpc-core/src/rpc-methods/__typetests__/simulate-transaction-typetest.ts
@@ -1,0 +1,266 @@
+import { Address } from '@solana/addresses';
+import {
+    Base58EncodedBytes,
+    Base58EncodedDataResponse,
+    Base64EncodedDataResponse,
+    Base64EncodedZStdCompressedDataResponse,
+    Commitment,
+    Rpc,
+    Slot,
+    U64UnsafeBeyond2Pow53Minus1,
+} from '@solana/rpc-types';
+import { Base64EncodedWireTransaction } from '@solana/transactions';
+
+import { SimulateTransactionApi } from '../simulateTransaction';
+
+const rpc = null as unknown as Rpc<SimulateTransactionApi>;
+const transactionBase58 = null as unknown as Base58EncodedBytes;
+const transactionBase64 = null as unknown as Base64EncodedWireTransaction;
+const address = 'Joe11111111111111111111111111111' as Address<'Joe11111111111111111111111111111'>;
+
+// Parameters
+const params = null as unknown as Parameters<SimulateTransactionApi['simulateTransaction']>[1];
+params satisfies
+    | {
+          accounts?: Readonly<{
+              addresses: Address[];
+              encoding?: 'base58' | 'base64' | 'base64+zstd' | 'jsonParsed' | undefined;
+          }>;
+      }
+    | undefined;
+params satisfies { commitment?: Commitment } | undefined;
+params satisfies { encoding?: 'base58' | 'base64' } | undefined;
+params satisfies { minContextSlot?: Slot } | undefined;
+params satisfies { replaceRecentBlockhash?: boolean } | undefined;
+params satisfies { sigVerify?: boolean } | undefined;
+
+async () => {
+    // `base58` transaction with `base58` accounts
+    {
+        const result = await rpc
+            .simulateTransaction(transactionBase58, { accounts: { addresses: [address], encoding: 'base58' } })
+            .send();
+        const { accounts } = result.value;
+        accounts.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base64`
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+            }
+        });
+    }
+
+    // `base58` transaction with `base64` accounts
+    {
+        const result = await rpc
+            .simulateTransaction(transactionBase58, { accounts: { addresses: [address], encoding: 'base64' } })
+            .send();
+        const { accounts } = result.value;
+        accounts.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58`
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+            }
+        });
+    }
+
+    // `base58` transaction with `base64+zstd` accounts
+    {
+        const result = await rpc
+            .simulateTransaction(transactionBase58, { accounts: { addresses: [address], encoding: 'base64+zstd' } })
+            .send();
+        const { accounts } = result.value;
+        accounts.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58`
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64`
+                data satisfies Base64EncodedDataResponse;
+            }
+        });
+    }
+
+    // `base58` transaction with `jsonParsed` accounts
+    {
+        const result = await rpc
+            .simulateTransaction(transactionBase58, { accounts: { addresses: [address], encoding: 'jsonParsed' } })
+            .send();
+        const { accounts } = result.value;
+        accounts.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies
+                    | Readonly<{
+                          program: string;
+                          parsed: {
+                              info?: object;
+                              type: string;
+                          };
+                          space: U64UnsafeBeyond2Pow53Minus1;
+                      }>
+                    | Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58`
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+                // @ts-expect-error should not be `base64` on its own
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `jsonParsed` on its own
+                data satisfies Readonly<{
+                    program: string;
+                    parsed: {
+                        info?: object;
+                        type: string;
+                    };
+                    space: U64UnsafeBeyond2Pow53Minus1;
+                }>;
+            }
+        });
+    }
+
+    // `base58` transaction with no account configs provided
+    {
+        const result = await rpc.simulateTransaction(transactionBase58).send();
+        result.value.accounts satisfies null;
+    }
+
+    // `base64` transaction with `base58` accounts
+    {
+        const result = await rpc
+            .simulateTransaction(transactionBase64, {
+                accounts: { addresses: [address], encoding: 'base58' },
+                encoding: 'base64',
+            })
+            .send();
+        const { accounts } = result.value;
+        accounts.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base64`
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+            }
+        });
+    }
+
+    // `base64` transaction with `base64` accounts
+    {
+        const result = await rpc
+            .simulateTransaction(transactionBase64, {
+                accounts: { addresses: [address], encoding: 'base64' },
+                encoding: 'base64',
+            })
+            .send();
+        const { accounts } = result.value;
+        accounts.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58`
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+            }
+        });
+    }
+
+    // `base64` transaction with `base64+zstd` accounts
+    {
+        const result = await rpc
+            .simulateTransaction(transactionBase64, {
+                accounts: { addresses: [address], encoding: 'base64+zstd' },
+                encoding: 'base64',
+            })
+            .send();
+        const { accounts } = result.value;
+        accounts.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58`
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64`
+                data satisfies Base64EncodedDataResponse;
+            }
+        });
+    }
+
+    // `base64` transaction with `jsonParsed` accounts
+    {
+        const result = await rpc
+            .simulateTransaction(transactionBase64, {
+                accounts: { addresses: [address], encoding: 'jsonParsed' },
+                encoding: 'base64',
+            })
+            .send();
+        const { accounts } = result.value;
+        accounts.forEach(account => {
+            if (account) {
+                const { data } = account;
+                data satisfies
+                    | Readonly<{
+                          program: string;
+                          parsed: {
+                              info?: object;
+                              type: string;
+                          };
+                          space: U64UnsafeBeyond2Pow53Minus1;
+                      }>
+                    | Base64EncodedDataResponse;
+                // @ts-expect-error should not be `base58` bytes
+                data satisfies Base58EncodedBytes;
+                // @ts-expect-error should not be `base58`
+                data satisfies Base58EncodedDataResponse;
+                // @ts-expect-error should not be `base64+zstd`
+                data satisfies Base64EncodedZStdCompressedDataResponse;
+                // @ts-expect-error should not be `base64` on its own
+                data satisfies Base64EncodedDataResponse;
+                // @ts-expect-error should not be `jsonParsed` on its own
+                data satisfies Readonly<{
+                    program: string;
+                    parsed: {
+                        info?: object;
+                        type: string;
+                    };
+                    space: U64UnsafeBeyond2Pow53Minus1;
+                }>;
+            }
+        });
+    }
+
+    // `base64` transaction with no account configs provided
+    {
+        const result = await rpc.simulateTransaction(transactionBase64, { encoding: 'base64' }).send();
+        result.value.accounts satisfies null;
+    }
+
+    // @ts-expect-error can't mix encodings
+    rpc.simulateTransaction(transactionBase58, { encoding: 'base64' });
+    // @ts-expect-error can't mix encodings
+    rpc.simulateTransaction(transactionBase64, { encoding: 'base58' });
+};

--- a/packages/rpc-core/src/rpc-methods/sendTransaction.ts
+++ b/packages/rpc-core/src/rpc-methods/sendTransaction.ts
@@ -1,5 +1,5 @@
 import type { Signature } from '@solana/keys';
-import type { Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
+import type { Base58EncodedBytes, Commitment, IRpcApiMethods, Slot } from '@solana/rpc-types';
 import type { Base64EncodedWireTransaction } from '@solana/transactions';
 
 type SendTransactionConfig = Readonly<{
@@ -14,7 +14,7 @@ type SendTransactionResponse = Signature;
 export interface SendTransactionApi extends IRpcApiMethods {
     /** @deprecated Set `encoding` to `'base64'` when calling this method */
     sendTransaction(
-        base64EncodedWireTransaction: Base64EncodedWireTransaction,
+        base58EncodedWireTransaction: Base58EncodedBytes,
         config?: SendTransactionConfig & { encoding?: 'base58' },
     ): SendTransactionResponse;
     /**


### PR DESCRIPTION
This commit continues the same work from previously in the stack, but here we've
hit a particular problem.

In the previous commits, all of the overload patterns have been completely
exhaustive, however in `sendTransaction` and `simulateTransaction`, we are
intentionally **not** using exhaustive patterns, so that we can type-check
against something like a `base64` encoded transaction provided without `{
encoding: 'base64' }`.

So I'm wondering how best to handle these two.
