### PR TITLE
draft: account errors

### DIFF
--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -64,6 +64,7 @@
     ],
     "dependencies": {
         "@solana/addresses": "workspace:*",
+        "@solana/errors": "workspace:*",
         "@solana/codecs-core": "workspace:*",
         "@solana/codecs-strings": "workspace:*",
         "@solana/rpc-spec": "workspace:*",

--- a/packages/accounts/src/__tests__/decode-account-test.ts
+++ b/packages/accounts/src/__tests__/decode-account-test.ts
@@ -1,6 +1,7 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
+import { SOLANA_ERROR__INVALID_ACCOUNT_DATA, SolanaError } from '@solana/errors';
 
 import { Account, EncodedAccount } from '../account';
 import { assertAccountDecoded, assertAccountsDecoded, decodeAccount } from '../decode-account';
@@ -86,7 +87,11 @@ describe('assertDecodedAccount', () => {
         const fn = () => assertAccountDecoded(account);
 
         // Then we expect an error to be thrown
-        expect(fn).toThrow('Expected account [1111] to be decoded.');
+        expect(fn).toThrow(
+            new SolanaError(SOLANA_ERROR__INVALID_ACCOUNT_DATA, {
+                addresses: [account.address],
+            }),
+        );
     });
 
     it('does not throw if the provided account is decoded', () => {
@@ -142,7 +147,11 @@ describe('assertDecodedAccounts', () => {
         const fn = () => assertAccountsDecoded(accounts);
 
         // Then we expect an error to be thrown
-        expect(fn).toThrow('Expected accounts [1111, 2222] to be decoded.');
+        expect(fn).toThrow(
+            new SolanaError(SOLANA_ERROR__INVALID_ACCOUNT_DATA, {
+                addresses: [accounts[0].address, accounts[1].address],
+            }),
+        );
     });
 
     it('does not throw if all of the provided accounts are decoded', () => {

--- a/packages/accounts/src/__tests__/maybe-account-test.ts
+++ b/packages/accounts/src/__tests__/maybe-account-test.ts
@@ -1,5 +1,7 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
+import { SOLANA_ERROR__ACCOUNT_NOT_FOUND, SolanaError } from '@solana/errors';
+
 import { assertAccountExists, assertAccountsExist, MaybeEncodedAccount } from '../maybe-account';
 
 describe('assertAccountExists', () => {
@@ -11,7 +13,11 @@ describe('assertAccountExists', () => {
         const fn = () => assertAccountExists(maybeAccount);
 
         // Then we expect an error to be thrown.
-        expect(fn).toThrow(`Expected account [1111] to exist`);
+        expect(fn).toThrow(
+            new SolanaError(SOLANA_ERROR__ACCOUNT_NOT_FOUND, {
+                addresses: [maybeAccount.address],
+            }),
+        );
     });
 });
 
@@ -28,7 +34,11 @@ describe('assertAccountsExist', () => {
         const fn = () => assertAccountsExist(maybeAccounts);
 
         // Then we expect an error to be thrown with the non-existent accounts
-        expect(fn).toThrow('Expected accounts [1111, 2222] to exist');
+        expect(fn).toThrow(
+            new SolanaError(SOLANA_ERROR__ACCOUNT_NOT_FOUND, {
+                addresses: [maybeAccounts[0].address, maybeAccounts[1].address],
+            }),
+        );
     });
 
     it('does not fail if all accounts exist', () => {

--- a/packages/accounts/src/maybe-account.ts
+++ b/packages/accounts/src/maybe-account.ts
@@ -1,4 +1,5 @@
 import { Address } from '@solana/addresses';
+import { SOLANA_ERROR__ACCOUNT_NOT_FOUND, SolanaError } from '@solana/errors';
 
 import { Account } from './account';
 
@@ -15,8 +16,7 @@ export function assertAccountExists<TData extends object | Uint8Array, TAddress 
     account: MaybeAccount<TData, TAddress>,
 ): asserts account is Account<TData, TAddress> & { exists: true } {
     if (!account.exists) {
-        // TODO: Coded error.
-        throw new Error(`Expected account [${account.address}] to exist.`);
+        throw new SolanaError(SOLANA_ERROR__ACCOUNT_NOT_FOUND, { addresses: [account.address] });
     }
 }
 
@@ -27,7 +27,6 @@ export function assertAccountsExist<TData extends object | Uint8Array, TAddress 
     const missingAccounts = accounts.filter(a => !a.exists);
     if (missingAccounts.length > 0) {
         const missingAddresses = missingAccounts.map(a => a.address);
-        // TODO: Coded error.
-        throw new Error(`Expected accounts [${missingAddresses.join(', ')}] to exist.`);
+        throw new SolanaError(SOLANA_ERROR__ACCOUNT_NOT_FOUND, { addresses: missingAddresses });
     }
 }

--- a/packages/errors/src/codes.ts
+++ b/packages/errors/src/codes.ts
@@ -13,6 +13,8 @@ export const SOLANA_ERROR__INVALID_KEYPAIR_BYTES = 4 as const;
 export const SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED = 5 as const;
 export const SOLANA_ERROR__NONCE_INVALID = 6 as const;
 export const SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND = 7 as const;
+export const SOLANA_ERROR__INVALID_ACCOUNT_DATA = 8 as const;
+export const SOLANA_ERROR__ACCOUNT_NOT_FOUND = 9 as const;
 
 /**
  * A union of every Solana error code
@@ -36,4 +38,6 @@ export type SolanaErrorCode =
     | typeof SOLANA_ERROR__INVALID_KEYPAIR_BYTES
     | typeof SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED
     | typeof SOLANA_ERROR__NONCE_INVALID
-    | typeof SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND;
+    | typeof SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND
+    | typeof SOLANA_ERROR__INVALID_ACCOUNT_DATA
+    | typeof SOLANA_ERROR__ACCOUNT_NOT_FOUND;

--- a/packages/errors/src/context.ts
+++ b/packages/errors/src/context.ts
@@ -1,5 +1,7 @@
 import {
+    SOLANA_ERROR__ACCOUNT_NOT_FOUND,
     SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED,
+    SOLANA_ERROR__INVALID_ACCOUNT_DATA,
     SOLANA_ERROR__INVALID_KEYPAIR_BYTES,
     SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND,
     SOLANA_ERROR__NONCE_INVALID,
@@ -20,6 +22,9 @@ export type DefaultUnspecifiedErrorContextToUndefined<T> = {
  *   - Don't change or remove members of an error's context.
  */
 export type SolanaErrorContext = DefaultUnspecifiedErrorContextToUndefined<{
+    [SOLANA_ERROR__ACCOUNT_NOT_FOUND]: {
+        addresses: string[];
+    };
     [SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED]: {
         currentBlockHeight: bigint;
         lastValidBlockHeight: bigint;
@@ -44,5 +49,9 @@ export type SolanaErrorContext = DefaultUnspecifiedErrorContextToUndefined<{
     [SOLANA_ERROR__NONCE_INVALID]: {
         actualNonceValue: string;
         expectedNonceValue: string;
+    };
+    [SOLANA_ERROR__INVALID_ACCOUNT_DATA]: {
+        addresses: string[];
+        cause?: Error;
     };
 }>;

--- a/packages/errors/src/messages.ts
+++ b/packages/errors/src/messages.ts
@@ -1,5 +1,7 @@
 import {
+    SOLANA_ERROR__ACCOUNT_NOT_FOUND,
     SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED,
+    SOLANA_ERROR__INVALID_ACCOUNT_DATA,
     SOLANA_ERROR__INVALID_KEYPAIR_BYTES,
     SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND,
     SOLANA_ERROR__NONCE_INVALID,
@@ -21,8 +23,10 @@ export const SolanaErrorMessages: Readonly<{
     // TypeScript will fail to build this project if add an error code without a message.
     [P in SolanaErrorCode]: string;
 }> = {
+    [SOLANA_ERROR__ACCOUNT_NOT_FOUND]: 'Account not found at addresses: $addresses.',
     [SOLANA_ERROR__BLOCK_HEIGHT_EXCEEDED]:
         'The network has progressed past the last block for which this transaction could have been committed.',
+    [SOLANA_ERROR__INVALID_ACCOUNT_DATA]: 'Invalid account data: $addresses.',
     [SOLANA_ERROR__INVALID_KEYPAIR_BYTES]: 'Key pair bytes must be of length 64, got $byteLength.',
     [SOLANA_ERROR__NONCE_ACCOUNT_NOT_FOUND]: 'No nonce account could be found at address `$nonceAccountAddress`',
     [SOLANA_ERROR__NONCE_INVALID]:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@solana/codecs-strings':
         specifier: workspace:*
         version: link:../codecs-strings
+      '@solana/errors':
+        specifier: workspace:*
+        version: link:../errors
       '@solana/rpc-spec':
         specifier: workspace:*
         version: link:../rpc-spec


### PR DESCRIPTION
DRAFT: NOT FOR MERGE: How's this looking?

I'm not sure if we want to stay consistent with any error enums from the SDK,
but here's a first brush at adding `SolanaError` codes to `@solana/accounts`.

If we are decoupling from the SDK, then providing pluralized errors might help
with this package.
