### PR TITLE
Ensure that any package that inlines another package builds that package first

### DIFF
--- a/packages/library-legacy/.eslintignore
+++ b/packages/library-legacy/.eslintignore
@@ -4,7 +4,7 @@ declarations/
 deploy/
 doc/
 lib/
-rollup.config.js
+rollup.config.mjs
+rollup.config.types.mjs
 test/.eslintrc.js
 test/dist/
-test/rollup.config.js

--- a/turbo.json
+++ b/turbo.json
@@ -28,12 +28,12 @@
         },
         "compile:js": {
             "dependsOn": ["clean", "^compile:js"],
-            "inputs": ["rollup.config.js", "tsconfig.*", "src/**"],
+            "inputs": ["rollup.config.mjs", "tsconfig.*", "src/**"],
             "outputs": ["dist/**", "lib/**"]
         },
         "compile:typedefs": {
             "dependsOn": ["clean", "^compile:typedefs"],
-            "inputs": ["rollup.config.types.js", "tsconfig.*", "src/**"],
+            "inputs": ["rollup.config.types.mjs", "tsconfig.*", "src/**"],
             "outputs": ["declarations/**", "dist/**/*.d.ts", "lib/**/*.d.ts"]
         },
         "publish-packages": {

--- a/turbo.json
+++ b/turbo.json
@@ -67,8 +67,8 @@
             "outputs": []
         },
         "style:fix": {
-            "inputs": ["src/**"],
-            "outputs": []
+            "inputs": ["*"],
+            "outputs": ["*"]
         },
         "test:lint": {
             "inputs": ["src/**", "test/**"],

--- a/turbo.json
+++ b/turbo.json
@@ -75,6 +75,7 @@
             "outputs": []
         },
         "test:live-with-test-validator": {
+            "dependsOn": ["^compile:js"],
             "inputs": ["babel.config.json", "src/**", "test/**"],
             "outputs": []
         },
@@ -88,12 +89,12 @@
             "outputs": []
         },
         "test:unit:browser": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["^compile:js"],
             "inputs": ["src/**"],
             "outputs": []
         },
         "test:unit:node": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["^compile:js"],
             "inputs": ["src/**"],
             "outputs": []
         },
@@ -110,7 +111,7 @@
             "outputs": []
         },
         "@solana/web3.js#test:unit:node": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["^compile:js"],
             "inputs": ["babel.config.json", "src/**", "test/**"],
             "outputs": []
         },

--- a/turbo.json
+++ b/turbo.json
@@ -76,7 +76,7 @@
             "inputs": ["babel.config.json", "src/**", "test/**"]
         },
         "test:prettier": {
-            "inputs": ["src/**", "test/**"]
+            "inputs": ["*"]
         },
         "test:typecheck": {
             "dependsOn": ["^compile:typedefs"],

--- a/turbo.json
+++ b/turbo.json
@@ -110,10 +110,20 @@
             "dependsOn": ["compile:js"],
             "outputs": []
         },
+        "@solana/web3.js#compile:js": {
+            "dependsOn": ["clean", "^compile:js"],
+            "inputs": ["babel.config.json", "rollup.config.mjs", "tsconfig.*", "src/**"],
+            "outputs": ["lib/**"]
+        },
         "@solana/web3.js#test:unit:node": {
             "dependsOn": ["^compile:js"],
             "inputs": ["babel.config.json", "src/**", "test/**"],
             "outputs": []
+        },
+        "@solana/web3.js-experimental#compile:js": {
+            "dependsOn": ["^compile:js"],
+            "inputs": ["tsconfig.*", "src/**"],
+            "outputs": ["dist/**"]
         },
         "@solana/web3.js-legacy-sham#compile:typedefs": {
             "dependsOn": ["@solana/web3.js#compile:typedefs", "^compile:typedefs"],

--- a/turbo.json
+++ b/turbo.json
@@ -49,8 +49,7 @@
                 "test:treeshakability:browser",
                 "test:treeshakability:native",
                 "test:treeshakability:node"
-            ],
-            "outputs": []
+            ]
         },
         "publish-packages-legacy": {
             "cache": false,
@@ -63,52 +62,42 @@
                 "test:prettier",
                 "test:typecheck",
                 "test:unit:node"
-            ],
-            "outputs": []
+            ]
         },
         "style:fix": {
             "inputs": ["*"],
             "outputs": ["*"]
         },
         "test:lint": {
-            "inputs": ["src/**", "test/**"],
-            "outputs": []
+            "inputs": ["src/**", "test/**"]
         },
         "test:live-with-test-validator": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["babel.config.json", "src/**", "test/**"],
-            "outputs": []
+            "inputs": ["babel.config.json", "src/**", "test/**"]
         },
         "test:prettier": {
-            "inputs": ["src/**", "test/**"],
-            "outputs": []
+            "inputs": ["src/**", "test/**"]
         },
         "test:typecheck": {
             "dependsOn": ["^compile:typedefs"],
-            "inputs": ["tsconfig.*", "src/**", "test/**"],
-            "outputs": []
+            "inputs": ["tsconfig.*", "src/**", "test/**"]
         },
         "test:unit:browser": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**"],
-            "outputs": []
+            "inputs": ["src/**"]
         },
         "test:unit:node": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["src/**"],
-            "outputs": []
+            "inputs": ["src/**"]
         },
         "test:treeshakability:browser": {
-            "dependsOn": ["compile:js"],
-            "outputs": []
+            "dependsOn": ["compile:js"]
         },
         "test:treeshakability:native": {
-            "dependsOn": ["compile:js"],
-            "outputs": []
+            "dependsOn": ["compile:js"]
         },
         "test:treeshakability:node": {
-            "dependsOn": ["compile:js"],
-            "outputs": []
+            "dependsOn": ["compile:js"]
         },
         "@solana/web3.js#compile:js": {
             "dependsOn": ["clean", "^compile:js"],
@@ -117,8 +106,7 @@
         },
         "@solana/web3.js#test:unit:node": {
             "dependsOn": ["^compile:js"],
-            "inputs": ["babel.config.json", "src/**", "test/**"],
-            "outputs": []
+            "inputs": ["babel.config.json", "src/**", "test/**"]
         },
         "@solana/web3.js-experimental#compile:js": {
             "dependsOn": ["^compile:js"],
@@ -127,8 +115,7 @@
         },
         "@solana/web3.js-legacy-sham#compile:typedefs": {
             "dependsOn": ["@solana/web3.js#compile:typedefs", "^compile:typedefs"],
-            "inputs": ["tsconfig.*", "src/**", "test/**"],
-            "outputs": []
+            "inputs": ["tsconfig.*", "src/**", "test/**"]
         }
     },
     "remoteCache": {

--- a/turbo.json
+++ b/turbo.json
@@ -99,6 +99,26 @@
         "test:treeshakability:node": {
             "dependsOn": ["compile:js"]
         },
+        "@solana/codecs-strings#compile:js": {
+            "dependsOn": ["^@solana/text-encoding-impl#compile:js"],
+            "inputs": ["tsconfig.*", "src/**"],
+            "outputs": ["dist/**"]
+        },
+        "@solana/signers#compile:js": {
+            "dependsOn": ["^@solana/text-encoding-impl#compile:js"],
+            "inputs": ["tsconfig.*", "src/**"],
+            "outputs": ["dist/**"]
+        },
+        "@solana/rpc-subscriptions-transport-websocket#compile:js": {
+            "dependsOn": ["^@solana/ws-impl#compile:js"],
+            "inputs": ["tsconfig.*", "src/**"],
+            "outputs": ["dist/**"]
+        },
+        "@solana/webcrypto-ed25519-polyfill#compile:js": {
+            "dependsOn": ["^@solana/crypto-impl#compile:js"],
+            "inputs": ["tsconfig.*", "src/**"],
+            "outputs": ["dist/**"]
+        },
         "@solana/web3.js#compile:js": {
             "dependsOn": ["clean", "^compile:js"],
             "inputs": ["babel.config.json", "rollup.config.mjs", "tsconfig.*", "src/**"],


### PR DESCRIPTION
Since these packages _inline_ this code, this is the one case of `compile:js` where you _do_ have to build the dependency first.
