### PR TITLE
Because libraries inline all of their code into iife bundles, they must build their upstreams first.

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -75,6 +75,7 @@
             "outputs": []
         },
         "test:live-with-test-validator": {
+            "dependsOn": ["^compile:js"],
             "inputs": ["babel.config.json", "src/**", "test/**"],
             "outputs": []
         },
@@ -88,12 +89,12 @@
             "outputs": []
         },
         "test:unit:browser": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["^compile:js"],
             "inputs": ["src/**"],
             "outputs": []
         },
         "test:unit:node": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["^compile:js"],
             "inputs": ["src/**"],
             "outputs": []
         },
@@ -110,7 +111,7 @@
             "outputs": []
         },
         "@solana/web3.js#test:unit:node": {
-            "dependsOn": ["compile:js"],
+            "dependsOn": ["^compile:js"],
             "inputs": ["babel.config.json", "src/**", "test/**"],
             "outputs": []
         },

--- a/turbo.json
+++ b/turbo.json
@@ -110,10 +110,20 @@
             "dependsOn": ["compile:js"],
             "outputs": []
         },
+        "@solana/web3.js#compile:js": {
+            "dependsOn": ["clean", "^compile:js"],
+            "inputs": ["babel.config.json", "rollup.config.mjs", "tsconfig.*", "src/**"],
+            "outputs": ["lib/**"]
+        },
         "@solana/web3.js#test:unit:node": {
             "dependsOn": ["^compile:js"],
             "inputs": ["babel.config.json", "src/**", "test/**"],
             "outputs": []
+        },
+        "@solana/web3.js-experimental#compile:js": {
+            "dependsOn": ["^compile:js"],
+            "inputs": ["tsconfig.*", "src/**"],
+            "outputs": ["dist/**"]
         },
         "@solana/web3.js-legacy-sham#compile:typedefs": {
             "dependsOn": ["@solana/web3.js#compile:typedefs", "^compile:typedefs"],


### PR DESCRIPTION
Unlike _packages_, these puppies build iife bundles, so they need to have access to the built source code of their dependencies.
