### PR TITLE
Cache `compiledMessage` when a transaction has signatures

### DIFF
--- a/packages/compat/src/__tests__/transaction-test.ts
+++ b/packages/compat/src/__tests__/transaction-test.ts
@@ -197,6 +197,24 @@ describe('fromVersionedTransactionWithBlockhash', () => {
             });
         });
 
+        it('caches the existing compiledMessage for a signed transaction', () => {
+            const compiledMessage = new TransactionMessage({
+                instructions: [],
+                payerKey: feePayerPublicKey,
+                recentBlockhash: blockhashString,
+            }).compileToLegacyMessage();
+            const oldTransaction = new VersionedTransaction(compiledMessage);
+
+            const feePayerSignature = new Uint8Array(Array(64).fill(1));
+            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
+
+            const transaction = fromVersionedTransactionWithBlockhash(
+                oldTransaction,
+            ) as unknown as ITransactionWithSignatures;
+
+            expect(transaction.compiledMessage).toStrictEqual(compiledMessage.serialize());
+        });
+
         it('converts a transaction with multiple signers', () => {
             const otherSigner1PublicKey = new PublicKey('8kud9bpNvfemXYdTFjs5cZ8fZinBkx8JAnhVmRwJZk5e');
             const otherSigner2PublicKey = new PublicKey('3LeBzRE9Yna5zi9R8vdT3MiNQYuEp4gJgVyhhwmqfCtd');
@@ -485,6 +503,24 @@ describe('fromVersionedTransactionWithBlockhash', () => {
             expect(transaction.signatures).toStrictEqual({
                 '7EqQdEULxWcraVx3mXKFjc84LhCkMGZCkRuDpvcMwJeK': feePayerSignature as SignatureBytes,
             });
+        });
+
+        it('caches the existing compiledMessage for a signed transaction', () => {
+            const compiledMessage = new TransactionMessage({
+                instructions: [],
+                payerKey: feePayerPublicKey,
+                recentBlockhash: blockhashString,
+            }).compileToV0Message();
+            const oldTransaction = new VersionedTransaction(compiledMessage);
+
+            const feePayerSignature = new Uint8Array(Array(64).fill(1));
+            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
+
+            const transaction = fromVersionedTransactionWithBlockhash(
+                oldTransaction,
+            ) as unknown as ITransactionWithSignatures;
+
+            expect(transaction.compiledMessage).toStrictEqual(compiledMessage.serialize());
         });
 
         it('converts a transaction with multiple signers', () => {
@@ -796,6 +832,31 @@ describe('fromVersionedTransactionWithDurableNonce', () => {
             });
         });
 
+        it('caches the existing compiledMessage for a signed transaction', () => {
+            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
+
+            const compiledMessage = new TransactionMessage({
+                instructions: [nonceAdvanceInstruction],
+                // Note there's a bug in legacy web3js where if the feepayer
+                // is the same as authorizedPubkey, it gets the wrong role
+                // in the advance nonce instruction
+                // So for our test just use a different account as fee payer
+                payerKey: feePayerPublicKey,
+                recentBlockhash: nonce,
+            }).compileToLegacyMessage();
+
+            const oldTransaction = new VersionedTransaction(compiledMessage);
+
+            const feePayerSignature = new Uint8Array(Array(64).fill(1));
+            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
+
+            const transaction = fromVersionedTransactionWithBlockhash(
+                oldTransaction,
+            ) as unknown as ITransactionWithSignatures;
+
+            expect(transaction.compiledMessage).toStrictEqual(compiledMessage.serialize());
+        });
+
         it('converts a durable nonce transaction with multiple signers', () => {
             const nonceAdvanceInstruction = createNonceAdvanceInstruction();
 
@@ -1030,6 +1091,31 @@ describe('fromVersionedTransactionWithDurableNonce', () => {
             expect(transaction.signatures).toStrictEqual({
                 '2KntmCrnaf63tpNb8UMFFjFGGnYYAKQdmW9SbuCiRvhM': signature as SignatureBytes,
             });
+        });
+
+        it('caches the existing compiledMessage for a signed transaction', () => {
+            const nonceAdvanceInstruction = createNonceAdvanceInstruction();
+
+            const compiledMessage = new TransactionMessage({
+                instructions: [nonceAdvanceInstruction],
+                // Note there's a bug in legacy web3js where if the feepayer
+                // is the same as authorizedPubkey, it gets the wrong role
+                // in the advance nonce instruction
+                // So for our test just use a different account as fee payer
+                payerKey: feePayerPublicKey,
+                recentBlockhash: nonce,
+            }).compileToV0Message();
+
+            const oldTransaction = new VersionedTransaction(compiledMessage);
+
+            const feePayerSignature = new Uint8Array(Array(64).fill(1));
+            oldTransaction.addSignature(feePayerPublicKey, feePayerSignature);
+
+            const transaction = fromVersionedTransactionWithBlockhash(
+                oldTransaction,
+            ) as unknown as ITransactionWithSignatures;
+
+            expect(transaction.compiledMessage).toStrictEqual(compiledMessage.serialize());
         });
 
         it('converts a durable nonce transaction with multiple signers', () => {

--- a/packages/compat/src/transaction.ts
+++ b/packages/compat/src/transaction.ts
@@ -129,6 +129,7 @@ export function fromVersionedTransactionWithBlockhash(
     );
 
     const signatures = convertSignatures(transaction, accountKeys.staticAccountKeys);
+    const compiledMessage = transaction.message.serialize();
 
     return pipe(
         createTransaction({ version: transaction.version }),
@@ -138,7 +139,7 @@ export function fromVersionedTransactionWithBlockhash(
             instructions.reduce((acc, instruction) => {
                 return appendTransactionInstruction(instruction, acc);
             }, tx),
-        tx => (transaction.signatures.length ? { ...tx, signatures } : tx),
+        tx => (transaction.signatures.length ? { ...tx, compiledMessage, signatures } : tx),
     );
 }
 
@@ -190,6 +191,7 @@ export function fromVersionedTransactionWithDurableNonce(
     };
 
     const signatures = convertSignatures(transaction, accountKeys.staticAccountKeys);
+    const compiledMessage = transaction.message.serialize();
 
     return pipe(
         createTransaction({ version: transaction.version }),
@@ -199,6 +201,6 @@ export function fromVersionedTransactionWithDurableNonce(
             instructions.slice(1).reduce((acc, instruction) => {
                 return appendTransactionInstruction(instruction, acc);
             }, tx),
-        tx => (transaction.signatures.length ? { ...tx, signatures } : tx),
+        tx => (transaction.signatures.length ? { ...tx, compiledMessage, signatures } : tx),
     );
 }

--- a/packages/signers/src/__tests__/fee-payer-signer-test.ts
+++ b/packages/signers/src/__tests__/fee-payer-signer-test.ts
@@ -1,7 +1,12 @@
 import '@solana/test-matchers/toBeFrozenObject';
 
 import { Address } from '@solana/addresses';
-import { BaseTransaction, ITransactionWithFeePayer, ITransactionWithSignatures } from '@solana/transactions';
+import {
+    BaseTransaction,
+    CompiledMessage,
+    ITransactionWithFeePayer,
+    ITransactionWithSignatures,
+} from '@solana/transactions';
 
 import { ITransactionWithFeePayerSigner, setTransactionFeePayerSigner } from '../fee-payer-signer';
 import { TransactionSigner } from '../transaction-signer';
@@ -44,6 +49,7 @@ describe('setTransactionFeePayerSigner', () => {
             beforeEach(() => {
                 txWithFeePayerAndSignatures = {
                     ...txWithFeePayerA,
+                    compiledMessage: {} as unknown as CompiledMessage,
                     signatures: {},
                 };
             });
@@ -84,6 +90,7 @@ describe('setTransactionFeePayerSigner', () => {
             beforeEach(() => {
                 txWithFeePayerAndSignatures = {
                     ...txWithFeePayerA,
+                    compiledMessage: {} as unknown as CompiledMessage,
                     signatures: {},
                 };
             });

--- a/packages/signers/src/__tests__/keypair-signer-test.ts
+++ b/packages/signers/src/__tests__/keypair-signer-test.ts
@@ -3,7 +3,7 @@ import '@solana/test-matchers/toBeFrozenObject';
 import { address, getAddressFromPublicKey } from '@solana/addresses';
 import { SOLANA_ERROR__SIGNER__EXPECTED_KEY_PAIR_SIGNER, SolanaError } from '@solana/errors';
 import { generateKeyPair, SignatureBytes, signBytes } from '@solana/keys';
-import { CompilableTransaction, partiallySignTransaction } from '@solana/transactions';
+import { CompilableTransaction, CompiledMessage, partiallySignTransaction } from '@solana/transactions';
 
 import {
     assertIsKeyPairSigner,
@@ -150,10 +150,12 @@ describe('createSignerFromKeyPair', () => {
         const mockSignatures = [new Uint8Array([101, 101, 101]), new Uint8Array([201, 201, 201])] as SignatureBytes[];
         jest.mocked(partiallySignTransaction).mockResolvedValueOnce({
             ...mockTransactions[0],
+            compiledMessage: {} as unknown as CompiledMessage,
             signatures: { [myAddress]: mockSignatures[0] },
         });
         jest.mocked(partiallySignTransaction).mockResolvedValueOnce({
             ...mockTransactions[1],
+            compiledMessage: {} as unknown as CompiledMessage,
             signatures: { [myAddress]: mockSignatures[1] },
         });
 

--- a/packages/signers/src/__tests__/sign-transaction-test.ts
+++ b/packages/signers/src/__tests__/sign-transaction-test.ts
@@ -6,7 +6,13 @@ import {
     SOLANA_ERROR__TRANSACTION__SIGNATURES_MISSING,
     SolanaError,
 } from '@solana/errors';
-import { CompilableTransaction, IFullySignedTransaction, ITransactionWithSignatures } from '@solana/transactions';
+import {
+    CompilableTransaction,
+    CompiledMessage,
+    compileMessage,
+    IFullySignedTransaction,
+    ITransactionWithSignatures,
+} from '@solana/transactions';
 
 import {
     partiallySignTransactionWithSigners,
@@ -201,7 +207,11 @@ describe('partiallySignTransactionWithSigners', () => {
         const transaction = createMockTransactionWithSigners([signerA, signerB]);
 
         // And given the following mocked signatures.
-        const modifiedTransaction = { ...transaction, signatures: { '1111': '1111_signature' } };
+        const modifiedTransaction = {
+            ...transaction,
+            compiledMessage: {} as unknown as CompiledMessage,
+            signatures: { '1111': '1111_signature' },
+        };
         signerA.modifyAndSignTransactions.mockResolvedValueOnce([modifiedTransaction]);
         signerB.signTransactions.mockResolvedValueOnce([{ '2222': '2222_signature' }]);
 
@@ -385,7 +395,13 @@ describe('signAndSendTransactionWithSigners', () => {
         // Then the sending signer was used to send the transaction.
         expect(signerA.signTransactions).toHaveBeenCalledWith([transaction], { abortSignal: undefined });
         expect(signerB.signAndSendTransactions).toHaveBeenCalledWith(
-            [{ ...transaction, signatures: { '1111': '1111_signature' } }],
+            [
+                {
+                    ...transaction,
+                    compiledMessage: compileMessage(transaction),
+                    signatures: { '1111': '1111_signature' },
+                },
+            ],
             { abortSignal: undefined },
         );
 
@@ -428,7 +444,13 @@ describe('signAndSendTransactionWithSigners', () => {
 
         // Then the composite signer was used as a sending signer.
         expect(signerA.signAndSendTransactions).toHaveBeenCalledWith(
-            [{ ...transaction, signatures: { '2222': '2222_signature' } }],
+            [
+                {
+                    ...transaction,
+                    compiledMessage: compileMessage(transaction),
+                    signatures: { '2222': '2222_signature' },
+                },
+            ],
             { abortSignal: undefined },
         );
         expect(signerA.signTransactions).not.toHaveBeenCalled();
@@ -447,7 +469,11 @@ describe('signAndSendTransactionWithSigners', () => {
         const transaction = createMockTransactionWithSigners([signerA, signerB]);
 
         // And given the following mocked signatures for these signers.
-        const modifiedTransaction = { ...transaction, signatures: { '1111': '1111_signature' } };
+        const modifiedTransaction = {
+            ...transaction,
+            compiledMessage: {} as unknown as CompiledMessage,
+            signatures: { '1111': '1111_signature' },
+        };
         signerA.modifyAndSignTransactions.mockResolvedValueOnce([modifiedTransaction]);
         signerB.signAndSendTransactions.mockResolvedValueOnce([new Uint8Array([1, 2, 3])]);
 
@@ -478,7 +504,11 @@ describe('signAndSendTransactionWithSigners', () => {
         // And given the following mocked signatures for these signers.
         signerA.signTransactions.mockResolvedValueOnce([{ '1111': '1111_signature' }]);
         signerB.signAndSendTransactions.mockResolvedValueOnce([new Uint8Array([1, 2, 3])]);
-        const modifiedTransaction = { ...transaction, signatures: { '3333': '3333_signature' } };
+        const modifiedTransaction = {
+            ...transaction,
+            compiledMessage: {} as unknown as CompiledMessage,
+            signatures: { '3333': '3333_signature' },
+        };
         signerC.modifyAndSignTransactions.mockResolvedValueOnce([modifiedTransaction]);
 
         // When we sign and send this transaction.
@@ -494,7 +524,13 @@ describe('signAndSendTransactionWithSigners', () => {
         expect(signerC.modifyAndSignTransactions).toHaveBeenCalledWith([transaction], { abortSignal: undefined });
         expect(transactionSignature).toStrictEqual(new Uint8Array([1, 2, 3]));
         expect(signerB.signAndSendTransactions).toHaveBeenCalledWith(
-            [{ ...transaction, signatures: { '1111': '1111_signature', '3333': '3333_signature' } }],
+            [
+                {
+                    ...transaction,
+                    compiledMessage: {} as unknown as CompiledMessage,
+                    signatures: { '1111': '1111_signature', '3333': '3333_signature' },
+                },
+            ],
             { abortSignal: undefined },
         );
     });

--- a/packages/signers/src/sign-transaction.ts
+++ b/packages/signers/src/sign-transaction.ts
@@ -3,6 +3,7 @@ import { SignatureBytes } from '@solana/keys';
 import {
     assertTransactionIsFullySigned,
     CompilableTransaction,
+    compileMessage,
     IFullySignedTransaction,
     ITransactionWithSignatures,
 } from '@solana/transactions';
@@ -192,8 +193,13 @@ async function signModifyingAndPartialTransactionSigners<
             return signatures;
         }),
     );
+    let compiledMessage = modifiedTransaction.compiledMessage;
+    if (!compiledMessage) {
+        compiledMessage = compileMessage(modifiedTransaction);
+    }
     const signedTransaction: ITransactionWithSignatures & TTransaction = {
         ...modifiedTransaction,
+        compiledMessage,
         signatures: Object.freeze(
             signatureDictionaries.reduce((signatures, signatureDictionary) => {
                 return { ...signatures, ...signatureDictionary };

--- a/packages/transaction-confirmation/src/__tests__/waiters-test.ts
+++ b/packages/transaction-confirmation/src/__tests__/waiters-test.ts
@@ -3,7 +3,7 @@ import { SOLANA_ERROR__TRANSACTION__FEE_PAYER_SIGNATURE_MISSING, SolanaError } f
 import { AccountRole, ReadonlySignerAccount, WritableAccount } from '@solana/instructions';
 import { Signature, SignatureBytes } from '@solana/keys';
 import type { Blockhash } from '@solana/rpc-types';
-import { IDurableNonceTransaction, Nonce } from '@solana/transactions';
+import { CompiledMessage, IDurableNonceTransaction, Nonce } from '@solana/transactions';
 
 import {
     waitForDurableNonceTransactionConfirmation,
@@ -17,6 +17,7 @@ const FOREVER_PROMISE = new Promise(() => {
 
 describe('waitForDurableNonceTransactionConfirmation', () => {
     const MOCK_DURABLE_NONCE_TRANSACTION = {
+        compiledMessage: {} as unknown as CompiledMessage,
         feePayer: '9'.repeat(44) as Address,
         instructions: [
             // Mock AdvanceNonce instruction.
@@ -189,6 +190,7 @@ describe('waitForDurableNonceTransactionConfirmation', () => {
 
 describe('waitForRecentTransactionConfirmation', () => {
     const MOCK_TRANSACTION = {
+        compiledMessage: {} as unknown as CompiledMessage,
         feePayer: '9'.repeat(44) as Address,
         lifetimeConstraint: { blockhash: '4'.repeat(44) as Blockhash, lastValidBlockHeight: 123n },
         signatures: {

--- a/packages/transactions/src/__tests__/blockhash-test.ts
+++ b/packages/transactions/src/__tests__/blockhash-test.ts
@@ -8,6 +8,7 @@ import {
     ITransactionWithBlockhashLifetime,
     setTransactionLifetimeUsingBlockhash,
 } from '../blockhash';
+import { CompiledMessage } from '../message';
 import { ITransactionWithSignatures } from '../signatures';
 import { BaseTransaction } from '../types';
 
@@ -134,6 +135,7 @@ describe('setTransactionLifetimeUsingBlockhash', () => {
             beforeEach(() => {
                 txWithBlockhashLifetimeConstraintAndSignatures = {
                     ...txWithBlockhashLifetimeConstraint,
+                    compiledMessage: {} as unknown as CompiledMessage,
                     signatures: {},
                 };
             });

--- a/packages/transactions/src/__tests__/compile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/compile-transaction-test.ts
@@ -27,6 +27,7 @@ describe('getCompiledTransaction', () => {
             staticAccounts: [addressB, addressA],
         } as CompiledMessage;
         (compileMessage as jest.Mock).mockReturnValue(mockCompiledMessage);
+        (compileMessage as jest.Mock).mockClear();
     });
     it('compiles the transaction message', () => {
         const compiledTransaction = getCompiledTransaction({} as Parameters<typeof getCompiledTransaction>[0]);
@@ -59,5 +60,21 @@ describe('getCompiledTransaction', () => {
             new Uint8Array(Array(64).fill(0)), // Missing signature for account B
             mockSignatureA,
         ]);
+    });
+    it('uses an existing compiled message if there is one', () => {
+        const compiledMessage = {
+            header: {
+                numReadonlyNonSignerAccounts: 1,
+                numReadonlySignerAccounts: 0,
+                numSignerAccounts: 1,
+            },
+            staticAccounts: [addressA, addressB],
+        } as CompiledMessage;
+        const transactionWithCompiledMessage = {
+            compiledMessage,
+        } as ITransactionWithSignatures & Parameters<typeof getCompiledTransaction>[0];
+        const compiledTransaction = getCompiledTransaction(transactionWithCompiledMessage);
+        expect(compiledTransaction).toHaveProperty('compiledMessage', compiledMessage);
+        expect(compileMessage).not.toHaveBeenCalled();
     });
 });

--- a/packages/transactions/src/__tests__/decompile-transaction-test.ts
+++ b/packages/transactions/src/__tests__/decompile-transaction-test.ts
@@ -221,6 +221,29 @@ describe('decompileTransaction', () => {
             });
         });
 
+        it('caches the existing compiledMessage when there are signatures', () => {
+            const feePayerSignature = new Uint8Array(Array(64).fill(1)) as SignatureBytes;
+
+            const compiledMessage = {
+                header: {
+                    numReadonlyNonSignerAccounts: 0,
+                    numReadonlySignerAccounts: 0,
+                    numSignerAccounts: 1,
+                },
+                instructions: [],
+                lifetimeToken: blockhash,
+                staticAccounts: [feePayer],
+                version: 0,
+            };
+            const compiledTransaction: CompiledTransaction = {
+                compiledMessage,
+                signatures: [feePayerSignature],
+            };
+
+            const transaction = decompileTransaction(compiledTransaction) as ITransactionWithSignatures;
+            expect(transaction.compiledMessage).toStrictEqual(compiledMessage);
+        });
+
         it('converts a transaction with multiple signers', () => {
             const feePayerSignature = new Uint8Array(Array(64).fill(1)) as SignatureBytes;
 

--- a/packages/transactions/src/__tests__/durable-nonce-test.ts
+++ b/packages/transactions/src/__tests__/durable-nonce-test.ts
@@ -11,6 +11,7 @@ import {
     Nonce,
     setTransactionLifetimeUsingDurableNonce,
 } from '../durable-nonce';
+import { CompiledMessage } from '../message';
 import { ITransactionWithSignatures } from '../signatures';
 import { BaseTransaction } from '../types';
 
@@ -256,6 +257,7 @@ describe('setTransactionLifetimeUsingDurableNonce', () => {
             beforeEach(() => {
                 durableNonceTxWithConstraintAAndSignatures = {
                     ...durableNonceTxWithConstraintA,
+                    compiledMessage: {} as unknown as CompiledMessage,
                     signatures: {},
                 };
             });

--- a/packages/transactions/src/__tests__/fee-payer-test.ts
+++ b/packages/transactions/src/__tests__/fee-payer-test.ts
@@ -3,6 +3,7 @@ import '@solana/test-matchers/toBeFrozenObject';
 import { Address } from '@solana/addresses';
 
 import { ITransactionWithFeePayer, setTransactionFeePayer } from '../fee-payer';
+import { CompiledMessage } from '../message';
 import { ITransactionWithSignatures } from '../signatures';
 import { BaseTransaction } from '../types';
 
@@ -44,6 +45,7 @@ describe('setTransactionFeePayer', () => {
             beforeEach(() => {
                 txWithFeePayerAndSignatures = {
                     ...txWithFeePayerA,
+                    compiledMessage: {} as unknown as CompiledMessage,
                     signatures: {},
                 };
             });

--- a/packages/transactions/src/__tests__/instructions-test.ts
+++ b/packages/transactions/src/__tests__/instructions-test.ts
@@ -9,6 +9,7 @@ import {
     prependTransactionInstruction,
     prependTransactionInstructions,
 } from '../instructions';
+import { CompiledMessage } from '../message';
 import { ITransactionWithSignatures } from '../signatures';
 import { BaseTransaction } from '../types';
 
@@ -49,6 +50,7 @@ describe('Transaction instruction helpers', () => {
             beforeEach(() => {
                 txWithSignatures = {
                     ...baseTx,
+                    compiledMessage: {} as unknown as CompiledMessage,
                     signatures: {},
                 };
             });
@@ -80,6 +82,7 @@ describe('Transaction instruction helpers', () => {
             beforeEach(() => {
                 txWithSignatures = {
                     ...baseTx,
+                    compiledMessage: {} as unknown as CompiledMessage,
                     signatures: {},
                 };
             });
@@ -107,6 +110,7 @@ describe('Transaction instruction helpers', () => {
             beforeEach(() => {
                 txWithSignatures = {
                     ...baseTx,
+                    compiledMessage: {} as unknown as CompiledMessage,
                     signatures: {},
                 };
             });
@@ -138,6 +142,7 @@ describe('Transaction instruction helpers', () => {
             beforeEach(() => {
                 txWithSignatures = {
                     ...baseTx,
+                    compiledMessage: {} as unknown as CompiledMessage,
                     signatures: {},
                 };
             });

--- a/packages/transactions/src/__tests__/signatures-test.ts
+++ b/packages/transactions/src/__tests__/signatures-test.ts
@@ -33,6 +33,7 @@ jest.mock('../message');
 describe('getSignatureFromTransaction', () => {
     it("returns the signature associated with a transaction's fee payer", () => {
         const transactionWithoutFeePayerSignature = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: '123' as Address,
             signatures: {
                 ['123' as Address]: new Uint8Array(new Array(64).fill(9)) as SignatureBytes,
@@ -44,6 +45,7 @@ describe('getSignatureFromTransaction', () => {
     });
     it('throws when supplied a transaction that has not been signed by the fee payer', () => {
         const transactionWithoutFeePayerSignature = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: '123' as Address,
             signatures: {
                 // No signature by the fee payer.
@@ -397,6 +399,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('throws if the transaction has no signature for the fee payer', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [],
             lifetimeConstraint: mockBlockhashConstraint,
@@ -413,6 +416,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('throws all missing signers if the transaction has no signature for multiple signers', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [
                 {
@@ -434,6 +438,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('throws if the transaction has no signature for an instruction readonly signer', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [
                 {
@@ -462,6 +467,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('throws if the transaction has no signature for an instruction writable signer', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [
                 {
@@ -490,6 +496,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('throws if the transaction has multiple instructions and one is missing a signer', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [
                 {
@@ -528,6 +535,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('does not throw if the transaction has no instructions and is signed by the fee payer', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [],
             lifetimeConstraint: mockBlockhashConstraint,
@@ -542,6 +550,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('does not throw if the transaction has an instruction and is signed by the fee payer and instruction signer', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [
                 {
@@ -567,6 +576,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('does not throw if the transaction has multiple instructions and is signed by all signers', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [
                 {
@@ -602,6 +612,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('does not throw if the transaction has an instruction with a non-signer account', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [
                 {
@@ -626,6 +637,7 @@ describe('assertTransactionIsFullySigned', () => {
 
     it('does not throw if the transaction has an instruction with no accounts', () => {
         const transaction: SignedTransaction = {
+            compiledMessage: {} as unknown as CompiledMessage,
             feePayer: mockPublicKeyAddressA,
             instructions: [
                 {

--- a/packages/transactions/src/compile-transaction.ts
+++ b/packages/transactions/src/compile-transaction.ts
@@ -12,7 +12,12 @@ export type CompiledTransaction = Readonly<{
 export function getCompiledTransaction(
     transaction: CompilableTransaction | (CompilableTransaction & ITransactionWithSignatures),
 ): CompiledTransaction {
-    const compiledMessage = compileMessage(transaction);
+    let compiledMessage: CompiledMessage;
+    if ('compiledMessage' in transaction && transaction.compiledMessage) {
+        compiledMessage = transaction.compiledMessage;
+    } else {
+        compiledMessage = compileMessage(transaction);
+    }
     let signatures;
     if ('signatures' in transaction) {
         signatures = [];

--- a/packages/transactions/src/decompile-transaction.ts
+++ b/packages/transactions/src/decompile-transaction.ts
@@ -245,6 +245,6 @@ export function decompileTransaction(
             'blockhash' in lifetimeConstraint
                 ? setTransactionLifetimeUsingBlockhash(lifetimeConstraint, tx)
                 : setTransactionLifetimeUsingDurableNonce(lifetimeConstraint, tx),
-        tx => (Object.keys(signatures).length > 0 ? { ...tx, signatures } : tx),
+        tx => (Object.keys(signatures).length > 0 ? { ...tx, compiledMessage, signatures } : tx),
     );
 }

--- a/packages/transactions/src/unsigned-transaction.ts
+++ b/packages/transactions/src/unsigned-transaction.ts
@@ -8,6 +8,7 @@ export function getUnsignedTransaction<TTransaction extends BaseTransaction>(
         // The implication of the lifetime constraint changing is that any existing signatures are invalid.
         const {
             signatures: _, // eslint-disable-line @typescript-eslint/no-unused-vars
+            compiledMessage: _c, // eslint-disable-line @typescript-eslint/no-unused-vars
             ...unsignedTransaction
         } = transaction;
         return unsignedTransaction;


### PR DESCRIPTION
When we sign a transaction, we actually sign the serialized bytes of its compiled message. This compiled message format is not very strictly defined by the spec, for example the order of accounts with the same role is not defined. This means that the message can be compiled in multiple valid ways. However, the signature bytes will only ever be valid with the exact same message bytes.

This PR adds `compiledMessage` to `ITransactionWithSignatures`, so that whenever we have a signed transaction we cache its `compiledMessage`. This is used instead instead of recompiling the message for future signatures, and when the transaction is compiled. If we do something that invalidates the signatures, then in addition to removing the signatures we also remove this cached `compiledMessage`. 

More importantly, it is set when we decode a serialized transaction if it has existing signatures. This cached `compiledMessage` will be valid for the existing signature, and will be used for any future signatures/when we compile/serialize the transaction. This means that the existing signature will remain valid. 

This allows us to deserialize, sign and reserialize a transaction created by code that compiles messages differently, eg. the legacy web3js library, without invalidating its signatures. 

Fixes #2362 