### PR TITLE
refactor(experimental): graphql: add `multipleAccounts` root query

### DIFF
--- a/packages/rpc-graphql/src/__tests__/multiple-accounts-test.ts
+++ b/packages/rpc-graphql/src/__tests__/multiple-accounts-test.ts
@@ -1,0 +1,1220 @@
+import {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
+
+import { createRpcGraphQL, RpcGraphQL } from '../index';
+import { createLocalhostSolanaRpc } from './__setup__';
+
+type GraphQLCompliantRpc = Rpc<
+    GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi
+>;
+
+describe('multiple accounts', () => {
+    let rpc: GraphQLCompliantRpc;
+    let rpcGraphQL: RpcGraphQL;
+    beforeEach(() => {
+        rpc = createLocalhostSolanaRpc();
+        rpcGraphQL = createRpcGraphQL(rpc);
+    });
+
+    describe('basic queries', () => {
+        const variableValues = {
+            addresses: [
+                // See scripts/fixtures/spl-token-token-account.json
+                'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                // See scripts/fixtures/spl-token-mint-account.json
+                'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+            ],
+        };
+        it("can query multiple accounts' lamports balance", async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        lamports
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            lamports: 10290815n,
+                        },
+                    ]),
+                },
+            });
+        });
+        it("can query multiple accounts' executable value", async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!, $commitment: Commitment) {
+                    multipleAccounts(addresses: $addresses, commitment: $commitment) {
+                        executable
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            executable: false,
+                        },
+                        {
+                            executable: false,
+                        },
+                    ]),
+                },
+            });
+        });
+        it("can query multiple accounts' address", async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!, $commitment: Commitment) {
+                    multipleAccounts(addresses: $addresses, commitment: $commitment) {
+                        address
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                        },
+                        {
+                            address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can query multiple fields', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!, $commitment: Commitment) {
+                    multipleAccounts(addresses: $addresses, commitment: $commitment) {
+                        executable
+                        lamports
+                        rentEpoch
+                        space
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            executable: false,
+                            lamports: 10290815n,
+                            rentEpoch: 0n,
+                            space: 165n,
+                        },
+                        {
+                            executable: false,
+                            lamports: 10290815n,
+                            rentEpoch: 0n,
+                            space: 82n,
+                        },
+                    ]),
+                },
+            });
+        });
+    });
+    describe('nested basic queries', () => {
+        const variableValues = {
+            addresses: [
+                // See scripts/fixtures/spl-token-token-account.json
+                'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                // See scripts/fixtures/spl-token-mint-account.json
+                'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+            ],
+            commitment: 'CONFIRMED',
+        };
+        it("can perform a nested query for the accounts' ownerProgram", async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!, $commitment: Commitment) {
+                    multipleAccounts(addresses: $addresses, commitment: $commitment) {
+                        ownerProgram {
+                            address
+                            executable
+                            lamports
+                            rentEpoch
+                            space
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                executable: true,
+                                lamports: expect.any(BigInt),
+                                rentEpoch: expect.any(BigInt),
+                                space: 133352n,
+                            },
+                        },
+                        {
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                executable: true,
+                                lamports: expect.any(BigInt),
+                                rentEpoch: expect.any(BigInt),
+                                space: 133352n,
+                            },
+                        },
+                    ]),
+                },
+            });
+        });
+    });
+    describe('double nested basic queries', () => {
+        const variableValues = {
+            addresses: [
+                // See scripts/fixtures/spl-token-token-account.json
+                'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                // See scripts/fixtures/spl-token-mint-account.json
+                'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+            ],
+            commitment: 'CONFIRMED',
+        };
+        it("can perform a double nested query for each account's ownerProgram", async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!, $commitment: Commitment) {
+                    multipleAccounts(addresses: $addresses, commitment: $commitment) {
+                        ownerProgram {
+                            address
+                            ownerProgram {
+                                address
+                                executable
+                                lamports
+                                rentEpoch
+                                space
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                ownerProgram: {
+                                    address: 'BPFLoader2111111111111111111111111111111111',
+                                    executable: true,
+                                    lamports: expect.any(BigInt),
+                                    rentEpoch: expect.any(BigInt),
+                                    space: 25n,
+                                },
+                            },
+                        },
+                        {
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                ownerProgram: {
+                                    address: 'BPFLoader2111111111111111111111111111111111',
+                                    executable: true,
+                                    lamports: expect.any(BigInt),
+                                    rentEpoch: expect.any(BigInt),
+                                    space: 25n,
+                                },
+                            },
+                        },
+                    ]),
+                },
+            });
+        });
+    });
+    describe('triple nested basic queries', () => {
+        const variableValues = {
+            addresses: [
+                // See scripts/fixtures/spl-token-token-account.json
+                'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                // See scripts/fixtures/spl-token-mint-account.json
+                'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+            ],
+            commitment: 'CONFIRMED',
+        };
+        it("can perform a triple nested query for each account's ownerProgram", async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        ownerProgram {
+                            address
+                            ownerProgram {
+                                address
+                                ownerProgram {
+                                    address
+                                }
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                ownerProgram: {
+                                    address: 'BPFLoader2111111111111111111111111111111111',
+                                    ownerProgram: {
+                                        address: 'NativeLoader1111111111111111111111111111111',
+                                    },
+                                },
+                            },
+                        },
+                        {
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                                ownerProgram: {
+                                    address: 'BPFLoader2111111111111111111111111111111111',
+                                    ownerProgram: {
+                                        address: 'NativeLoader1111111111111111111111111111111',
+                                    },
+                                },
+                            },
+                        },
+                    ]),
+                },
+            });
+        });
+    });
+    describe('account data queries', () => {
+        const addresses = [
+            // See scripts/fixtures/gpa2-1.json
+            'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+            // See scripts/fixtures/gpa2-2.json
+            'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+        ];
+        it('can get account data as base58', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        data(encoding: BASE_58)
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            data: '2Uw1bpnsXxu3e',
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            data: '2Uw1bpnsXxu3e',
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data as base58 with data slice', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        data(encoding: BASE_58, dataSlice: { offset: 0, length: 5 })
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            data: 'E8f4pET', // As tested on local RPC
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            data: 'E8f4pET', // As tested on local RPC
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data as base64', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        data(encoding: BASE_64)
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            data: 'dGVzdCBkYXRh',
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            data: 'dGVzdCBkYXRh',
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data as base64 with data slice', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        data(encoding: BASE_64, dataSlice: { offset: 0, length: 5 })
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            data: 'dGVzdCA=', // As tested on local RPC
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            data: 'dGVzdCA=', // As tested on local RPC
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data as base64 with two data slices', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        dataA: data(encoding: BASE_64, dataSlice: { offset: 2, length: 5 })
+                        dataB: data(encoding: BASE_64, dataSlice: { offset: 4, length: 5 })
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            dataA: 'c3QgZGE=', // As tested on local RPC
+                            dataB: 'IGRhdGE=', // As tested on local RPC
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            dataA: 'c3QgZGE=', // As tested on local RPC
+                            dataB: 'IGRhdGE=', // As tested on local RPC
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data as base64+zstd', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        data(encoding: BASE_64_ZSTD)
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            data: 'KLUv/QBYSQAAdGVzdCBkYXRh',
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            data: 'KLUv/QBYSQAAdGVzdCBkYXRh',
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data as base64+zstd with data slice', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        data(encoding: BASE_64_ZSTD, dataSlice: { offset: 0, length: 15 })
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            data: 'KLUv/QBYSQAAdGVzdCBkYXRh', // As tested on local RPC
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            data: 'KLUv/QBYSQAAdGVzdCBkYXRh', // As tested on local RPC
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data as base64+zstd with multiple data slices', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        dataA: data(encoding: BASE_64_ZSTD, dataSlice: { offset: 0, length: 5 })
+                        dataB: data(encoding: BASE_64_ZSTD, dataSlice: { offset: 0, length: 15 })
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            dataA: 'KLUv/QBYKQAAdGVzdCA=', // As tested on local RPC
+                            dataB: 'KLUv/QBYSQAAdGVzdCBkYXRh', // As tested on local RPC
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            dataA: 'KLUv/QBYKQAAdGVzdCA=', // As tested on local RPC
+                            dataB: 'KLUv/QBYSQAAdGVzdCBkYXRh', // As tested on local RPC
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data with multiple encodings', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        dataBase58: data(encoding: BASE_58)
+                        dataBase64: data(encoding: BASE_64)
+                        dataBase64Zstd: data(encoding: BASE_64_ZSTD)
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            dataBase58: '2Uw1bpnsXxu3e',
+                            dataBase64: 'dGVzdCBkYXRh',
+                            dataBase64Zstd: 'KLUv/QBYSQAAdGVzdCBkYXRh',
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            dataBase58: '2Uw1bpnsXxu3e',
+                            dataBase64: 'dGVzdCBkYXRh',
+                            dataBase64Zstd: 'KLUv/QBYSQAAdGVzdCBkYXRh',
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data with multiple encodings and data slices', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        dataBase58: data(encoding: BASE_58, dataSlice: { offset: 0, length: 5 })
+                        dataBase64: data(encoding: BASE_64, dataSlice: { offset: 0, length: 5 })
+                        dataBase64Zstd: data(encoding: BASE_64_ZSTD, dataSlice: { offset: 0, length: 5 })
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, { addresses });
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'C5q1p5UiCVrt6vcLJDGcS4AZ98fahKyb9XkDRdqATK17',
+                            dataBase58: 'E8f4pET', // As tested on local RPC
+                            dataBase64: 'dGVzdCA=', // As tested on local RPC
+                            dataBase64Zstd: 'KLUv/QBYKQAAdGVzdCA=', // As tested on local RPC
+                        },
+                        {
+                            address: 'Hhsoev7Apk5dMbktzLUrsTHuMq9e9GSYBaLcnN2PfdKS',
+                            dataBase58: 'E8f4pET', // As tested on local RPC
+                            dataBase64: 'dGVzdCA=', // As tested on local RPC
+                            dataBase64Zstd: 'KLUv/QBYKQAAdGVzdCA=', // As tested on local RPC
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get account data as jsonParsed', async () => {
+            expect.assertions(1);
+            const addresses = [
+                // See scripts/fixtures/spl-token-token-account.json
+                'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                // See scripts/fixtures/spl-token-mint-account.json
+                'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+            ];
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        ... on MintAccount {
+                            supply
+                        }
+                        ... on TokenAccount {
+                            tokenAmount {
+                                amount
+                            }
+                        }
+                    }
+                }
+            `;
+            const resultParsed = await rpcGraphQL.query(source, {
+                addresses,
+            });
+            expect(resultParsed).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            supply: expect.any(String),
+                        },
+                        {
+                            tokenAmount: {
+                                amount: expect.any(String),
+                            },
+                        },
+                    ]),
+                },
+            });
+        });
+    });
+    describe('specific account type queries', () => {
+        it('can get nonce accounts', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/nonce-account.json
+            const variableValues = {
+                addresses: [
+                    'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
+                    'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
+                ],
+            };
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        lamports
+                        ownerProgram {
+                            address
+                        }
+                        rentEpoch
+                        space
+                        ... on NonceAccount {
+                            authority {
+                                address
+                            }
+                            blockhash
+                            feeCalculator {
+                                lamportsPerSignature
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
+                            authority: {
+                                address: '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe',
+                            },
+                            blockhash: expect.any(String),
+                            feeCalculator: {
+                                lamportsPerSignature: expect.any(String),
+                            },
+                            lamports: expect.any(BigInt),
+                            ownerProgram: {
+                                address: '11111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 80n,
+                        },
+                        {
+                            address: 'AiZExP8mK4RxDozh4r57knvqSZgkz86HrzPAMx61XMqU',
+                            authority: {
+                                address: '3xxDCjN8s6MgNHwdRExRLa6gHmmRTWPnUdzkbKfEgNAe',
+                            },
+                            blockhash: expect.any(String),
+                            feeCalculator: {
+                                lamportsPerSignature: expect.any(String),
+                            },
+                            lamports: expect.any(BigInt),
+                            ownerProgram: {
+                                address: '11111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 80n,
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get address lookup table accounts', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/address-lookup-table-account.json
+            const variableValues = {
+                addresses: [
+                    '2JPQuT3dHtPjrdcbUQyrrT4XYRYaWpWfmAJ54SUapg6n',
+                    '2JPQuT3dHtPjrdcbUQyrrT4XYRYaWpWfmAJ54SUapg6n',
+                ],
+            };
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        lamports
+                        ownerProgram {
+                            address
+                        }
+                        rentEpoch
+                        space
+                        ... on LookupTableAccount {
+                            addresses
+                            authority {
+                                address
+                            }
+                            deactivationSlot
+                            lastExtendedSlot
+                            lastExtendedSlotStartIndex
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: '2JPQuT3dHtPjrdcbUQyrrT4XYRYaWpWfmAJ54SUapg6n',
+                            addresses: expect.any(Array),
+                            authority: {
+                                address: '4msgK65vdz5ADUAB3eTQGpF388NuQUAoknLxutUQJd5B',
+                            },
+                            deactivationSlot: expect.any(String),
+                            lamports: expect.any(BigInt),
+                            lastExtendedSlot: expect.any(String),
+                            lastExtendedSlotStartIndex: expect.any(Number),
+                            ownerProgram: {
+                                address: 'AddressLookupTab1e1111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 1304n,
+                        },
+                        {
+                            address: '2JPQuT3dHtPjrdcbUQyrrT4XYRYaWpWfmAJ54SUapg6n',
+                            addresses: expect.any(Array),
+                            authority: {
+                                address: '4msgK65vdz5ADUAB3eTQGpF388NuQUAoknLxutUQJd5B',
+                            },
+                            deactivationSlot: expect.any(String),
+                            lamports: expect.any(BigInt),
+                            lastExtendedSlot: expect.any(String),
+                            lastExtendedSlotStartIndex: expect.any(Number),
+                            ownerProgram: {
+                                address: 'AddressLookupTab1e1111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 1304n,
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get mint accounts', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/spl-token-mint-account.json
+            const variableValues = {
+                addresses: [
+                    'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                    'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                ],
+            };
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        lamports
+                        ownerProgram {
+                            address
+                        }
+                        rentEpoch
+                        space
+                        ... on MintAccount {
+                            decimals
+                            isInitialized
+                            mintAuthority {
+                                address
+                                lamports
+                            }
+                            supply
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            decimals: 6,
+                            isInitialized: true,
+                            lamports: expect.any(BigInt),
+                            mintAuthority: {
+                                address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                                lamports: expect.any(BigInt),
+                            },
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 82n,
+                            supply: expect.any(String),
+                        },
+                        {
+                            address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                            decimals: 6,
+                            isInitialized: true,
+                            lamports: expect.any(BigInt),
+                            mintAuthority: {
+                                address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                                lamports: expect.any(BigInt),
+                            },
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 82n,
+                            supply: expect.any(String),
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get token accounts', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/spl-token-token-account.json
+            const variableValues = {
+                addresses: [
+                    'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                    'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                ],
+            };
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        lamports
+                        ownerProgram {
+                            address
+                        }
+                        rentEpoch
+                        space
+                        ... on TokenAccount {
+                            isNative
+                            mint {
+                                address
+                            }
+                            owner {
+                                address
+                            }
+                            state
+                            tokenAmount {
+                                amount
+                                decimals
+                                uiAmount
+                                uiAmountString
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                            isNative: expect.any(Boolean),
+                            lamports: expect.any(BigInt),
+                            mint: {
+                                address: expect.any(String),
+                            },
+                            owner: {
+                                address: '6UsGbaMgchgj4wiwKKuE1v5URHdcDfEiMSM25QpesKir',
+                            },
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 165n,
+                            state: expect.any(String),
+                            tokenAmount: {
+                                amount: expect.any(String),
+                                decimals: expect.any(Number),
+                                uiAmount: null,
+                                uiAmountString: expect.any(String),
+                            },
+                        },
+                        {
+                            address: 'AyGCwnwxQMCqaU4ixReHt8h5W4dwmxU7eM3BEQBdWVca',
+                            isNative: expect.any(Boolean),
+                            lamports: expect.any(BigInt),
+                            mint: {
+                                address: expect.any(String),
+                            },
+                            owner: {
+                                address: '6UsGbaMgchgj4wiwKKuE1v5URHdcDfEiMSM25QpesKir',
+                            },
+                            ownerProgram: {
+                                address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 165n,
+                            state: expect.any(String),
+                            tokenAmount: {
+                                amount: expect.any(String),
+                                decimals: expect.any(Number),
+                                uiAmount: null,
+                                uiAmountString: expect.any(String),
+                            },
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get stake accounts', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/stake-account.json
+            const variableValues = {
+                addresses: [
+                    'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN',
+                    'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN',
+                ],
+            };
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        lamports
+                        ownerProgram {
+                            address
+                        }
+                        rentEpoch
+                        space
+                        ... on StakeAccount {
+                            meta {
+                                authorized {
+                                    staker {
+                                        address
+                                    }
+                                    withdrawer {
+                                        address
+                                    }
+                                }
+                                lockup {
+                                    custodian {
+                                        address
+                                    }
+                                    epoch
+                                    unixTimestamp
+                                }
+                                rentExemptReserve
+                            }
+                            stake {
+                                creditsObserved
+                                delegation {
+                                    activationEpoch
+                                    deactivationEpoch
+                                    stake
+                                    voter {
+                                        address
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: 'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN',
+                            lamports: expect.any(BigInt),
+                            meta: {
+                                authorized: {
+                                    staker: {
+                                        address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+                                    },
+                                    withdrawer: {
+                                        address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+                                    },
+                                },
+                                lockup: {
+                                    custodian: {
+                                        address: '11111111111111111111111111111111',
+                                    },
+                                    epoch: expect.any(BigInt),
+                                    unixTimestamp: expect.any(BigInt),
+                                },
+                                rentExemptReserve: expect.any(String),
+                            },
+                            ownerProgram: {
+                                address: 'Stake11111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 200n,
+                            stake: {
+                                creditsObserved: expect.any(BigInt),
+                                delegation: {
+                                    activationEpoch: expect.any(BigInt),
+                                    deactivationEpoch: expect.any(BigInt),
+                                    stake: expect.any(String),
+                                    voter: {
+                                        address: 'CertusDeBmqN8ZawdkxK5kFGMwBXdudvWHYwtNgNhvLu',
+                                    },
+                                },
+                            },
+                        },
+                        {
+                            address: 'CSg2vQGbnwWdSyJpwK4i3qGfB6FebaV3xQTx4U1MbixN',
+                            lamports: expect.any(BigInt),
+                            meta: {
+                                authorized: {
+                                    staker: {
+                                        address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+                                    },
+                                    withdrawer: {
+                                        address: '3HRNKNXafhr3wE9NSXRpNVdFYt6EVygdqFwqf6WpG57V',
+                                    },
+                                },
+                                lockup: {
+                                    custodian: {
+                                        address: '11111111111111111111111111111111',
+                                    },
+                                    epoch: expect.any(BigInt),
+                                    unixTimestamp: expect.any(BigInt),
+                                },
+                                rentExemptReserve: expect.any(String),
+                            },
+                            ownerProgram: {
+                                address: 'Stake11111111111111111111111111111111111111',
+                            },
+                            rentEpoch: expect.any(BigInt),
+                            space: 200n,
+                            stake: {
+                                creditsObserved: expect.any(BigInt),
+                                delegation: {
+                                    activationEpoch: expect.any(BigInt),
+                                    deactivationEpoch: expect.any(BigInt),
+                                    stake: expect.any(String),
+                                    voter: {
+                                        address: 'CertusDeBmqN8ZawdkxK5kFGMwBXdudvWHYwtNgNhvLu',
+                                    },
+                                },
+                            },
+                        },
+                    ]),
+                },
+            });
+        });
+        it('can get vote accounts', async () => {
+            expect.assertions(1);
+            // See scripts/fixtures/vote-account.json
+            const variableValues = {
+                addresses: [
+                    '4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp',
+                    '4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp',
+                ],
+            };
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        address
+                        lamports
+                        ownerProgram {
+                            address
+                        }
+                        rentEpoch
+                        space
+                        ... on VoteAccount {
+                            authorizedVoters {
+                                authorizedVoter {
+                                    address
+                                }
+                                epoch
+                            }
+                            authorizedWithdrawer {
+                                address
+                            }
+                            commission
+                            epochCredits {
+                                credits
+                                epoch
+                                previousCredits
+                            }
+                            lastTimestamp {
+                                slot
+                                timestamp
+                            }
+                            node {
+                                address
+                            }
+                            priorVoters
+                            rootSlot
+                            votes {
+                                confirmationCount
+                                slot
+                            }
+                        }
+                    }
+                }
+            `;
+            const result = await rpcGraphQL.query(source, variableValues);
+            expect(result).toMatchObject({
+                data: {
+                    multipleAccounts: expect.arrayContaining([
+                        {
+                            address: '4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp',
+                            authorizedVoters: expect.arrayContaining([
+                                {
+                                    authorizedVoter: {
+                                        address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                                    },
+                                    epoch: expect.any(BigInt),
+                                },
+                            ]),
+                            authorizedWithdrawer: {
+                                address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                            },
+                            commission: expect.any(Number),
+                            epochCredits: expect.arrayContaining([
+                                {
+                                    credits: expect.any(String),
+                                    epoch: expect.any(BigInt),
+                                    previousCredits: expect.any(String),
+                                },
+                            ]),
+                            lamports: expect.any(BigInt),
+                            lastTimestamp: {
+                                slot: expect.any(BigInt),
+                                timestamp: expect.any(BigInt),
+                            },
+                            node: {
+                                address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                            },
+                            ownerProgram: {
+                                address: 'Vote111111111111111111111111111111111111111',
+                            },
+                            priorVoters: expect.any(Array),
+                            rentEpoch: expect.any(BigInt),
+                            rootSlot: expect.any(BigInt),
+                            space: 3762n,
+                            votes: expect.arrayContaining([
+                                {
+                                    confirmationCount: expect.any(Number),
+                                    slot: expect.any(BigInt),
+                                },
+                            ]),
+                        },
+                        {
+                            address: '4QUZQ4c7bZuJ4o4L8tYAEGnePFV27SUFEVmC7BYfsXRp',
+                            authorizedVoters: expect.arrayContaining([
+                                {
+                                    authorizedVoter: {
+                                        address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                                    },
+                                    epoch: expect.any(BigInt),
+                                },
+                            ]),
+                            authorizedWithdrawer: {
+                                address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                            },
+                            commission: expect.any(Number),
+                            epochCredits: expect.arrayContaining([
+                                {
+                                    credits: expect.any(String),
+                                    epoch: expect.any(BigInt),
+                                    previousCredits: expect.any(String),
+                                },
+                            ]),
+                            lamports: expect.any(BigInt),
+                            lastTimestamp: {
+                                slot: expect.any(BigInt),
+                                timestamp: expect.any(BigInt),
+                            },
+                            node: {
+                                address: 'HMU77m6WSL9Xew9YvVCgz1hLuhzamz74eD9avi4XPdr',
+                            },
+                            ownerProgram: {
+                                address: 'Vote111111111111111111111111111111111111111',
+                            },
+                            priorVoters: expect.any(Array),
+                            rentEpoch: expect.any(BigInt),
+                            rootSlot: expect.any(BigInt),
+                            space: 3762n,
+                            votes: expect.arrayContaining([
+                                {
+                                    confirmationCount: expect.any(Number),
+                                    slot: expect.any(BigInt),
+                                },
+                            ]),
+                        },
+                    ]),
+                },
+            });
+        });
+    });
+});

--- a/packages/rpc-graphql/src/loaders/__tests__/multiple-accounts-loader-test.ts
+++ b/packages/rpc-graphql/src/loaders/__tests__/multiple-accounts-loader-test.ts
@@ -1,0 +1,1205 @@
+import type {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
+
+import { createRpcGraphQL, RpcGraphQL } from '../../index';
+
+const FOREVER_PROMISE = new Promise(() => {
+    /* never resolve */
+});
+
+describe('multiple accounts loader', () => {
+    let rpc: {
+        getAccountInfo: jest.MockedFunction<Rpc<GetAccountInfoApi>['getAccountInfo']>;
+        getBlock: jest.MockedFunction<Rpc<GetBlockApi>['getBlock']>;
+        getMultipleAccounts: jest.MockedFunction<Rpc<GetMultipleAccountsApi>['getMultipleAccounts']>;
+        getProgramAccounts: jest.MockedFunction<Rpc<GetProgramAccountsApi>['getProgramAccounts']>;
+        getTransaction: jest.MockedFunction<Rpc<GetTransactionApi>['getTransaction']>;
+    };
+    let rpcGraphQL: RpcGraphQL;
+    // Random addresses for testing.
+    // Not actually used. Just needed for proper query parsing.
+    const addresses = [
+        '54BtAvQ9agJjeb5q8vLMEbf72KwcyfMu87JhhcXCnAoq',
+        '6mTPNpsyXsv8Anx3E9rzV6uwwebFruftAHoZRdp4iCeo',
+        'C8ShshN7Xgt91sNn2aHZvDPLFikJWJTD52xstCAudfvH',
+        'c63MKv6fzJMaiKSyA3xnWFXn7YGi9aBXGFzFB86ZhKB',
+        '3yKcat17YswFjy8LF2UTjbEGi7RxmHczZiCEH5zrpoCe',
+        'DxFfzP8BV9bfeRYyt5DqEc51MYx73Uvzji67CNbt1VhN',
+    ];
+    beforeEach(() => {
+        jest.useFakeTimers();
+        rpc = {
+            getAccountInfo: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
+            getBlock: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
+            getMultipleAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
+            getProgramAccounts: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
+            getTransaction: jest.fn().mockReturnValue({ send: jest.fn().mockReturnValue(FOREVER_PROMISE) }),
+        };
+        rpcGraphQL = createRpcGraphQL(
+            rpc as unknown as Rpc<
+                GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi
+            >,
+        );
+    });
+    describe('cached responses', () => {
+        it('coalesces multiple requests for the same accounts into one', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts1: multipleAccounts(addresses: $addresses) {
+                        lamports
+                    }
+                    multipleAccounts2: multipleAccounts(addresses: $addresses) {
+                        lamports
+                    }
+                    multipleAccounts3: multipleAccounts(addresses: $addresses) {
+                        lamports
+                    }
+                }
+            `;
+            rpcGraphQL.query(source, { addresses });
+            await jest.runAllTimersAsync();
+            expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+        });
+        it('cache resets on new tick', async () => {
+            expect.assertions(1);
+            const source = /* GraphQL */ `
+                query testQuery($addresses: [Address!]!) {
+                    multipleAccounts(addresses: $addresses) {
+                        lamports
+                    }
+                }
+            `;
+            // Call the query twice
+            rpcGraphQL.query(source, { addresses });
+            rpcGraphQL.query(source, { addresses });
+            await jest.runAllTimersAsync();
+            expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+        });
+    });
+    describe('batch loading', () => {
+        describe('request partitioning', () => {
+            it('coalesces multiple requests for the same accounts but different fields into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts1: multipleAccounts(addresses: $addresses) {
+                            lamports
+                        }
+                        multipleAccounts2: multipleAccounts(addresses: $addresses) {
+                            space
+                        }
+                        multipleAccounts3: multipleAccounts(addresses: $addresses) {
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('coalesces multiple requests for the same accounts but one with specified `confirmed` commitment into one request', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts1: multipleAccounts(addresses: $addresses) {
+                            lamports
+                        }
+                        multipleAccounts2: multipleAccounts(addresses: $addresses, commitment: CONFIRMED) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+            it('will not coalesce multiple requests for the same account but with different commitments into one request', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts1: multipleAccounts(addresses: $addresses) {
+                            lamports
+                        }
+                        multipleAccounts2: multipleAccounts(addresses: $addresses, commitment: CONFIRMED) {
+                            lamports
+                        }
+                        multipleAccounts3: multipleAccounts(addresses: $addresses, commitment: FINALIZED) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                    commitment: 'finalized',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+            it('coalesces multiple requests for multiple accounts into one `getMultipleAccounts` request', async () => {
+                expect.assertions(2);
+                const address1 = addresses[0];
+                const address2 = addresses[1];
+                const address3 = addresses[2];
+                const address4 = addresses[3];
+                const address5 = addresses[4];
+                const address6 = addresses[5];
+                const source = /* GraphQL */ `
+                    query testQuery(
+                        $addresses1: [Address!]!
+                        $addresses2: [Address!]!
+                        $addresses3: [Address!]!
+                        $addresses4: [Address!]!
+                        $addresses5: [Address!]!
+                        $addresses6: [Address!]!
+                    ) {
+                        multipleAccounts1: multipleAccounts(addresses: $addresses1) {
+                            lamports
+                        }
+                        multipleAccounts2: multipleAccounts(addresses: $addresses2) {
+                            lamports
+                        }
+                        multipleAccounts3: multipleAccounts(addresses: $addresses3) {
+                            lamports
+                        }
+                        multipleAccounts4: multipleAccounts(addresses: $addresses4) {
+                            lamports
+                        }
+                        multipleAccounts5: multipleAccounts(addresses: $addresses5) {
+                            lamports
+                        }
+                        multipleAccounts6: multipleAccounts(addresses: $addresses6) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, {
+                    addresses1: [address1],
+                    addresses2: [address2],
+                    addresses3: [address3],
+                    addresses4: [address4],
+                    addresses5: [address5],
+                    addresses6: [address6],
+                });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+            it('coalesces multiple requests for multiple accounts into one `getMultipleAccounts` request, coalescing `confirmed` commitments', async () => {
+                expect.assertions(2);
+                const addressesChunk1 = addresses.slice(0, 2);
+                const addressesChunk2 = addresses.slice(2, 4);
+                const addressesChunk3 = addresses.slice(4);
+                const source = /* GraphQL */ `
+                    query testQuery(
+                        $addressesChunk1: [Address!]!
+                        $addressesChunk2: [Address!]!
+                        $addressesChunk3: [Address!]!
+                    ) {
+                        multipleAccounts1: multipleAccounts(addresses: $addressesChunk1) {
+                            lamports
+                        }
+                        multipleAccounts1Confirmed: multipleAccounts(
+                            addresses: $addressesChunk1
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        multipleAccounts2: multipleAccounts(addresses: $addressesChunk2) {
+                            lamports
+                        }
+                        multipleAccounts2Confirmed: multipleAccounts(
+                            addresses: $addressesChunk2
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        multipleAccounts3: multipleAccounts(addresses: $addressesChunk3) {
+                            lamports
+                        }
+                        multipleAccounts3Confirmed: multipleAccounts(
+                            addresses: $addressesChunk3
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addressesChunk1, addressesChunk2, addressesChunk3 });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+            it('will not coalesce multiple requests for multiple accounts into one `getMultipleAccounts` request when different commitments are requested', async () => {
+                expect.assertions(3);
+                const addressesChunk1 = addresses.slice(0, 2);
+                const addressesChunk2 = addresses.slice(2, 4);
+                const addressesChunk3 = addresses.slice(4);
+                const source = /* GraphQL */ `
+                    query testQuery(
+                        $addressesChunk1: [Address!]!
+                        $addressesChunk2: [Address!]!
+                        $addressesChunk3: [Address!]!
+                    ) {
+                        multipleAccounts1: multipleAccounts(addresses: $addressesChunk1) {
+                            lamports
+                        }
+                        multipleAccounts1Confirmed: multipleAccounts(
+                            addresses: $addressesChunk1
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        multipleAccounts1Finalized: multipleAccounts(
+                            addresses: $addressesChunk1
+                            commitment: FINALIZED
+                        ) {
+                            lamports
+                        }
+                        multipleAccounts2: multipleAccounts(addresses: $addressesChunk2) {
+                            lamports
+                        }
+                        multipleAccounts2Confirmed: multipleAccounts(
+                            addresses: $addressesChunk2
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        multipleAccounts2Finalized: multipleAccounts(
+                            addresses: $addressesChunk2
+                            commitment: FINALIZED
+                        ) {
+                            lamports
+                        }
+                        multipleAccounts3: multipleAccounts(addresses: $addressesChunk3) {
+                            lamports
+                        }
+                        multipleAccounts3Confirmed: multipleAccounts(
+                            addresses: $addressesChunk3
+                            commitment: CONFIRMED
+                        ) {
+                            lamports
+                        }
+                        multipleAccounts3Finalized: multipleAccounts(
+                            addresses: $addressesChunk3
+                            commitment: FINALIZED
+                        ) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addressesChunk1, addressesChunk2, addressesChunk3 });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                    commitment: 'finalized',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+            it('breaks multiple account requests into multiple `getMultipleAccounts` requests if the batch limit is exceeded', async () => {
+                expect.assertions(3);
+
+                rpcGraphQL = createRpcGraphQL(
+                    rpc as unknown as Rpc<
+                        GetAccountInfoApi &
+                            GetBlockApi &
+                            GetMultipleAccountsApi &
+                            GetProgramAccountsApi &
+                            GetTransactionApi
+                    >,
+                    { maxMultipleAccountsBatchSize: 3 }, // const `addresses` has 6 elements.
+                );
+
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses.slice(0, 3), {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses.slice(3), {
+                    commitment: 'confirmed',
+                    encoding: 'base64', // GraphQL client prefers `base64`
+                });
+            });
+        });
+        describe('encoding requests', () => {
+            it('does not use `jsonParsed` if no parsed type is queried', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            lamports
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+            });
+            it('uses only `base58` if one data field is requested with `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            data(encoding: BASE_58)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                });
+            });
+            it('uses only `base64` if one data field is requested with `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            data(encoding: BASE_64)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+            });
+            it('uses only `base64+zstd` if one data field is requested with `base64+zstd` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            data(encoding: BASE_64_ZSTD)
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64+zstd',
+                });
+            });
+            it('only uses `jsonParsed` if a parsed type is queried, but data is not', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('does not call the loader twice for other base fields and `base58` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            data(encoding: BASE_58)
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                });
+            });
+            it('does not call the loader twice for other base fields and `base64` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            data(encoding: BASE_64)
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+            });
+            it('does not call the loader twice for other base fields and `base64+zstd` encoding', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            data(encoding: BASE_64_ZSTD)
+                            lamports
+                            space
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64+zstd',
+                });
+            });
+            it('does not call the loader twice for other base fields and inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            lamports
+                            space
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('will not make multiple calls for more than one inline fragment', async () => {
+                expect.assertions(2);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            ... on MintAccount {
+                                supply
+                            }
+                            ... on TokenAccount {
+                                lamports
+                            }
+                            ... on NonceAccount {
+                                blockhash
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('uses `jsonParsed` and the requested data encoding if a parsed type is queried alongside encoded data', async () => {
+                expect.assertions(3);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            data(encoding: BASE_64)
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+            it('uses only the number of requests for the number of different encodings requested', async () => {
+                expect.assertions(4);
+                const source = /* GraphQL */ `
+                    query testQuery($addresses: [Address!]!) {
+                        multipleAccounts(addresses: $addresses) {
+                            dataBase58_1: data(encoding: BASE_58)
+                            dataBase58_2: data(encoding: BASE_58)
+                            dataBase58_3: data(encoding: BASE_58)
+                            dataBase64_1: data(encoding: BASE_64)
+                            dataBase64_2: data(encoding: BASE_64)
+                            dataBase64_3: data(encoding: BASE_64)
+                            ... on MintAccount {
+                                supply
+                            }
+                        }
+                    }
+                `;
+                rpcGraphQL.query(source, { addresses });
+                await jest.runAllTimersAsync();
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(3);
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base58',
+                });
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'base64',
+                });
+                expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                    commitment: 'confirmed',
+                    encoding: 'jsonParsed',
+                });
+            });
+        });
+        describe('data slice requests', () => {
+            describe('single multipleAccounts queries', () => {
+                it('does not call the loader twice for data slice and other fields', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccounts(addresses: $addresses) {
+                                data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                lamports
+                                space
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                    expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 10, offset: 0 },
+                        encoding: 'base64',
+                    });
+                });
+                it('coalesces a data with no data slice and data with data slice within byte limit to the same request', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccounts(addresses: $addresses) {
+                                dataWithNoSlice: data(encoding: BASE_64)
+                                dataWithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                    expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                    });
+                });
+                it('coalesces non-sliced and sliced data requests across encodings', async () => {
+                    expect.assertions(3);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccounts(addresses: $addresses) {
+                                dataBase58WithNoSlice: data(encoding: BASE_58)
+                                dataBase58WithSlice: data(encoding: BASE_58, dataSlice: { length: 10, offset: 0 })
+                                dataBase64WithNoSlice: data(encoding: BASE_64)
+                                dataBase64WithSlice: data(encoding: BASE_64, dataSlice: { length: 20, offset: 4 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        encoding: 'base58', // No `dataSlice` arg since one field asked for the whole data
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                    });
+                });
+                it('always uses separate requests for `base64+zstd` no matter the data slice', async () => {
+                    expect.assertions(4);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccounts(addresses: $addresses) {
+                                dataBase64ZstdWithNoSlice: data(encoding: BASE_64_ZSTD)
+                                dataBase64ZstdWithSlice1: data(
+                                    encoding: BASE_64_ZSTD
+                                    dataSlice: { length: 16, offset: 4 }
+                                )
+                                dataBase64ZstdWithSlice2: data(
+                                    encoding: BASE_64_ZSTD
+                                    dataSlice: { length: 40, offset: 12 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(3);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        encoding: 'base64+zstd',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 16, offset: 4 },
+                        encoding: 'base64+zstd',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 40, offset: 12 },
+                        encoding: 'base64+zstd',
+                    });
+                });
+                it('coalesces multiple data slice requests within byte limit to the same request', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccounts(addresses: $addresses) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { length: 16, offset: 2 })
+                                dataSlice3: data(encoding: BASE_64, dataSlice: { length: 20, offset: 6 })
+                                dataSlice4: data(encoding: BASE_64, dataSlice: { length: 10, offset: 10 })
+                                dataSlice5: data(encoding: BASE_64, dataSlice: { length: 10, offset: 30 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 40, offset: 0 }, // Coalesced into one slice
+                        encoding: 'base64',
+                    });
+                });
+                it('splits multiple data slice requests beyond byte limit into two requests', async () => {
+                    expect.assertions(3);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccounts(addresses: $addresses) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { length: 4, offset: 0 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { length: 4, offset: 2000 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base64',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 2000 },
+                        encoding: 'base64',
+                    });
+                });
+                it('honors the byte limit across encodings', async () => {
+                    expect.assertions(5);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccounts(addresses: $addresses) {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { length: 4, offset: 0 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { length: 4, offset: 2000 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { length: 4, offset: 0 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { length: 4, offset: 2000 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(4);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base58',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 2000 },
+                        encoding: 'base58',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base64',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 2000 },
+                        encoding: 'base64',
+                    });
+                });
+            });
+            describe('multiple multipleAccounts queries', () => {
+                it('does not call the loader twice for data slice and other fields', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccountsA: multipleAccounts(addresses: $addresses) {
+                                data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                lamports
+                                space
+                            }
+                            multipleAccountsB: multipleAccounts(addresses: $addresses) {
+                                data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                lamports
+                                space
+                            }
+                            multipleAccountsC: multipleAccounts(addresses: $addresses) {
+                                data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                                lamports
+                                space
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                    expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 10, offset: 0 },
+                        encoding: 'base64',
+                    });
+                });
+                it('coalesces a data with no data slice and data with data slice within byte limit to the same request', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccountsA: multipleAccounts(addresses: $addresses) {
+                                dataWithNoSlice: data(encoding: BASE_64)
+                                dataWithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                            multipleAccountsB: multipleAccounts(addresses: $addresses) {
+                                dataWithNoSlice: data(encoding: BASE_64)
+                                dataWithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                            multipleAccountsC: multipleAccounts(addresses: $addresses) {
+                                dataWithNoSlice: data(encoding: BASE_64)
+                                dataWithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                    expect(rpc.getMultipleAccounts).toHaveBeenLastCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                    });
+                });
+                it('coalesces non-sliced and sliced data requests across encodings', async () => {
+                    expect.assertions(3);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccountsA: multipleAccounts(addresses: $addresses) {
+                                dataBase58WithNoSlice: data(encoding: BASE_58)
+                                dataBase58WithSlice: data(encoding: BASE_58, dataSlice: { length: 10, offset: 0 })
+                                dataBase64WithNoSlice: data(encoding: BASE_64)
+                                dataBase64WithSlice: data(encoding: BASE_64, dataSlice: { length: 12, offset: 4 })
+                            }
+                            multipleAccountsB: multipleAccounts(addresses: $addresses) {
+                                dataBase58WithNoSlice: data(encoding: BASE_58)
+                                dataBase58WithSlice: data(encoding: BASE_58, dataSlice: { length: 14, offset: 4 })
+                                dataBase64WithNoSlice: data(encoding: BASE_64)
+                                dataBase64WithSlice: data(encoding: BASE_64, dataSlice: { length: 10, offset: 0 })
+                            }
+                            multipleAccountsC: multipleAccounts(addresses: $addresses) {
+                                dataBase58WithNoSlice: data(encoding: BASE_58)
+                                dataBase58WithSlice: data(encoding: BASE_58, dataSlice: { length: 10, offset: 50 })
+                                dataBase64WithNoSlice: data(encoding: BASE_64)
+                                dataBase64WithSlice: data(encoding: BASE_64, dataSlice: { length: 100, offset: 0 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        encoding: 'base58', // No `dataSlice` arg since one field asked for the whole data
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        encoding: 'base64', // No `dataSlice` arg since one field asked for the whole data
+                    });
+                });
+                it('coalesces multiple data slice requests within byte limit to the same request', async () => {
+                    expect.assertions(2);
+                    const source = /* GraphQL */ `
+                        query testQuery($addresses: [Address!]!) {
+                            multipleAccountsA: multipleAccounts(addresses: $addresses) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 10 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2, length: 16 })
+                                dataSlice3: data(encoding: BASE_64, dataSlice: { offset: 6, length: 20 })
+                                dataSlice4: data(encoding: BASE_64, dataSlice: { offset: 10, length: 10 })
+                                dataSlice5: data(encoding: BASE_64, dataSlice: { offset: 30, length: 10 })
+                            }
+                            multipleAccountsB: multipleAccounts(addresses: $addresses) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 10 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2, length: 16 })
+                                dataSlice3: data(encoding: BASE_64, dataSlice: { offset: 6, length: 20 })
+                                dataSlice4: data(encoding: BASE_64, dataSlice: { offset: 10, length: 10 })
+                                dataSlice5: data(encoding: BASE_64, dataSlice: { offset: 30, length: 10 })
+                            }
+                            multipleAccountsC: multipleAccounts(addresses: $addresses) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 10 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2, length: 16 })
+                                dataSlice3: data(encoding: BASE_64, dataSlice: { offset: 6, length: 20 })
+                                dataSlice4: data(encoding: BASE_64, dataSlice: { offset: 10, length: 10 })
+                                dataSlice5: data(encoding: BASE_64, dataSlice: { offset: 30, length: 10 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addresses });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(1);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 40, offset: 0 }, // Coalesced into one slice
+                        encoding: 'base64',
+                    });
+                });
+                it('splits multiple data slice requests beyond the default byte limit into two requests', async () => {
+                    expect.assertions(3);
+                    const addressesChunk1 = addresses.slice(0, 2);
+                    const addressesChunk2 = addresses.slice(2, 4);
+                    const addressesChunk3 = addresses.slice(4);
+                    const source = /* GraphQL */ `
+                        query testQuery(
+                            $addressesChunk1: [Address!]!
+                            $addressesChunk2: [Address!]!
+                            $addressesChunk3: [Address!]!
+                        ) {
+                            multipleAccountsA: multipleAccounts(addresses: $addressesChunk1) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2000, length: 4 })
+                            }
+                            multipleAccountsB: multipleAccounts(addresses: $addressesChunk2) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2000, length: 4 })
+                            }
+                            multipleAccountsC: multipleAccounts(addresses: $addressesChunk3) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(encoding: BASE_64, dataSlice: { offset: 2000, length: 4 })
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addressesChunk1, addressesChunk2, addressesChunk3 });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base64',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 2000 },
+                        encoding: 'base64',
+                    });
+                });
+                it('splits multiple data slice requests beyond a provided byte limit into two requests', async () => {
+                    expect.assertions(3);
+                    const addressesChunk1 = addresses.slice(0, 2);
+                    const addressesChunk2 = addresses.slice(2, 4);
+                    const addressesChunk3 = addresses.slice(4);
+                    const maxDataSliceByteRange = 100;
+                    rpcGraphQL = createRpcGraphQL(
+                        rpc as unknown as Rpc<
+                            GetAccountInfoApi &
+                                GetBlockApi &
+                                GetMultipleAccountsApi &
+                                GetProgramAccountsApi &
+                                GetTransactionApi
+                        >,
+                        {
+                            maxDataSliceByteRange,
+                        },
+                    );
+                    const source = /* GraphQL */ `
+                        query testQuery(
+                            $addressesChunk1: [Address!]!
+                            $addressesChunk2: [Address!]!
+                            $addressesChunk3: [Address!]!
+                            $maxDataSliceByteRange: Int!
+                        ) {
+                            multipleAccountsA: multipleAccounts(addresses: $addressesChunk1) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                            multipleAccountsB: multipleAccounts(addresses: $addressesChunk2) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                            multipleAccountsC: multipleAccounts(addresses: $addressesChunk3) {
+                                dataSlice1: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataSlice2: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, {
+                        addressesChunk1,
+                        addressesChunk2,
+                        addressesChunk3,
+                        maxDataSliceByteRange,
+                    });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(2);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base64',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: maxDataSliceByteRange },
+                        encoding: 'base64',
+                    });
+                });
+                it('honors the default byte limit across encodings', async () => {
+                    expect.assertions(5);
+                    const addressesChunk1 = addresses.slice(0, 2);
+                    const addressesChunk2 = addresses.slice(2, 4);
+                    const addressesChunk3 = addresses.slice(4);
+                    const source = /* GraphQL */ `
+                        query testQuery(
+                            $addressesChunk1: [Address!]!
+                            $addressesChunk2: [Address!]!
+                            $addressesChunk3: [Address!]!
+                        ) {
+                            multipleAccountsA: multipleAccounts(addresses: $addressesChunk1) {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                            }
+                            multipleAccountsB: multipleAccounts(addresses: $addressesChunk2) {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                            }
+                            multipleAccountsC: multipleAccounts(addresses: $addressesChunk3) {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: 2000, length: 4 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, { addressesChunk1, addressesChunk2, addressesChunk3 });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(4);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base58',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 2000 },
+                        encoding: 'base58',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base64',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 2000 },
+                        encoding: 'base64',
+                    });
+                });
+                it('honors a provided byte limit across encodings', async () => {
+                    expect.assertions(5);
+                    const addressesChunk1 = addresses.slice(0, 2);
+                    const addressesChunk2 = addresses.slice(2, 4);
+                    const addressesChunk3 = addresses.slice(4);
+                    const maxDataSliceByteRange = 100;
+                    rpcGraphQL = createRpcGraphQL(
+                        rpc as unknown as Rpc<
+                            GetAccountInfoApi &
+                                GetBlockApi &
+                                GetMultipleAccountsApi &
+                                GetProgramAccountsApi &
+                                GetTransactionApi
+                        >,
+                        {
+                            maxDataSliceByteRange,
+                        },
+                    );
+                    const source = /* GraphQL */ `
+                        query testQuery(
+                            $addressesChunk1: [Address!]!
+                            $addressesChunk2: [Address!]!
+                            $addressesChunk3: [Address!]!
+                            $maxDataSliceByteRange: Int!
+                        ) {
+                            multipleAccountsA: multipleAccounts(addresses: $addressesChunk1) {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                            multipleAccountsB: multipleAccounts(addresses: $addressesChunk2) {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                            multipleAccountsC: multipleAccounts(addresses: $addressesChunk3) {
+                                dataBase58WithinByteLimit: data(encoding: BASE_58, dataSlice: { offset: 0, length: 4 })
+                                dataBase58BeyondByteLimit: data(
+                                    encoding: BASE_58
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                                dataBase64WithinByteLimit: data(encoding: BASE_64, dataSlice: { offset: 0, length: 4 })
+                                dataBase64BeyondByteLimit: data(
+                                    encoding: BASE_64
+                                    dataSlice: { offset: $maxDataSliceByteRange, length: 4 }
+                                )
+                            }
+                        }
+                    `;
+                    rpcGraphQL.query(source, {
+                        addressesChunk1,
+                        addressesChunk2,
+                        addressesChunk3,
+                        maxDataSliceByteRange,
+                    });
+                    await jest.runAllTimersAsync();
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledTimes(4);
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base58',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: maxDataSliceByteRange },
+                        encoding: 'base58',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: 0 },
+                        encoding: 'base64',
+                    });
+                    expect(rpc.getMultipleAccounts).toHaveBeenCalledWith(addresses, {
+                        commitment: 'confirmed',
+                        dataSlice: { length: 4, offset: maxDataSliceByteRange },
+                        encoding: 'base64',
+                    });
+                });
+            });
+        });
+    });
+});

--- a/packages/rpc-graphql/src/loaders/account.ts
+++ b/packages/rpc-graphql/src/loaders/account.ts
@@ -134,8 +134,9 @@ function createAccountBatchLoadFn(rpc: Rpc<GetAccountInfoApi & GetMultipleAccoun
                     return Array.from({ length: 1 }, async () => {
                         try {
                             const result = await resolveAccountUsingRpc({ address, ...args });
+                            const resultWithAddress = { ...result, address };
                             addressCallbacks[address].callbacks.forEach(({ callback, dataSlice }) => {
-                                callback.resolve(sliceData(result, dataSlice, args.dataSlice));
+                                callback.resolve(sliceData(resultWithAddress, dataSlice, args.dataSlice));
                             });
                         } catch (e) {
                             addressCallbacks[address].callbacks.forEach(({ callback }) => {
@@ -155,10 +156,14 @@ function createAccountBatchLoadFn(rpc: Rpc<GetAccountInfoApi & GetMultipleAccoun
                                     addresses: chunk,
                                     ...args,
                                 });
+                                const resultsWithAddress = results.map((result, ii) => ({
+                                    ...result,
+                                    address: chunk[ii],
+                                }));
                                 chunk.forEach((address, ii) => {
-                                    const result = results[ii];
+                                    const resultWithAddress = resultsWithAddress[ii];
                                     addressCallbacks[address].callbacks.forEach(({ callback, dataSlice }) => {
-                                        callback.resolve(sliceData(result, dataSlice, args.dataSlice));
+                                        callback.resolve(sliceData(resultWithAddress, dataSlice, args.dataSlice));
                                     });
                                 });
                             } catch (e) {

--- a/packages/rpc-graphql/src/loaders/loader.ts
+++ b/packages/rpc-graphql/src/loaders/loader.ts
@@ -21,7 +21,9 @@ export type AccountLoaderArgsBase = {
     minContextSlot?: Slot;
 };
 export type AccountLoaderArgs = AccountLoaderArgsBase & { address: Address };
-export type AccountLoaderValue = ReturnType<GetAccountInfoApi['getAccountInfo']>['value'] | null;
+export type AccountLoaderValue =
+    | (ReturnType<GetAccountInfoApi['getAccountInfo']>['value'] & { address: Address })
+    | null;
 export type AccountLoader = Loader<AccountLoaderArgs, AccountLoaderValue>;
 
 export type BlockLoaderArgsBase = {

--- a/packages/rpc-graphql/src/resolvers/root.ts
+++ b/packages/rpc-graphql/src/resolvers/root.ts
@@ -1,6 +1,6 @@
 import type { makeExecutableSchema } from '@graphql-tools/schema';
 
-import { resolveAccount } from './account';
+import { resolveAccount, resolveMultipleAccounts } from './account';
 import { resolveBlock } from './block';
 import { resolveProgramAccounts } from './program-accounts';
 import { resolveTransaction } from './transaction';
@@ -9,6 +9,7 @@ export const rootResolvers: Parameters<typeof makeExecutableSchema>[0]['resolver
     Query: {
         account: resolveAccount(),
         block: resolveBlock(),
+        multipleAccounts: resolveMultipleAccounts(),
         programAccounts: resolveProgramAccounts(),
         transaction: resolveTransaction(),
     },

--- a/packages/rpc-graphql/src/schema/root.ts
+++ b/packages/rpc-graphql/src/schema/root.ts
@@ -2,6 +2,7 @@ export const rootTypeDefs = /* GraphQL */ `
     type Query {
         account(address: Address!, commitment: Commitment, minContextSlot: Slot): Account
         block(slot: Slot!, commitment: CommitmentWithoutProcessed): Block
+        multipleAccounts(addresses: [Address!]!, commitment: Commitment, minContextSlot: Slot): [Account]
         programAccounts(
             programAddress: Address!
             commitment: Commitment


### PR DESCRIPTION
#### Problem
The GraphQL resolver currently supports root queries for `account` and
`programAccounts`, but not for `multipleAccounts`. A user can craft multiple
`account` queries in one source, but why go through the trouble if all fields and
input parameters are the same?

Additionally, if the GraphQL resolver had a `resolveMultipleAccounts` resolver
function, it would make things much easier to add list-based account lookups
on schema types that would otherwise return `[Address]`. With this new resolver,
they can instead return `[Account]`, which would allow nested queries on these
lists.

#### Summary of Changes
Introduce the `mutipleAccounts` root query.

I've reimplemented the same tests for this new `multipleAccounts` query
as those already provided for the existing `accounts` query.

- `src/__tests__/account-test.ts`
- `src/loaders/__tests__/account-loader-test.ts`

ie:

- `src/__tests__/multiple-accounts-test.ts`
- `src/loaders/__tests__/multiple-accounts-loader-test.ts`