### PR TITLE
refactor(experimental): graphql: enable schema extending

### DIFF
--- a/packages/rpc-graphql/src/__tests__/customization-test.ts
+++ b/packages/rpc-graphql/src/__tests__/customization-test.ts
@@ -1,0 +1,127 @@
+import {
+    GetAccountInfoApi,
+    GetBlockApi,
+    GetMultipleAccountsApi,
+    GetProgramAccountsApi,
+    GetTransactionApi,
+    Rpc,
+} from '@solana/rpc';
+
+import { createRpcGraphQL, resolveAccount } from '../index';
+import { createLocalhostSolanaRpc } from './__setup__';
+
+type GraphQLCompliantRpc = Rpc<
+    GetAccountInfoApi & GetBlockApi & GetMultipleAccountsApi & GetProgramAccountsApi & GetTransactionApi
+>;
+
+describe('schema customization', () => {
+    let rpc: GraphQLCompliantRpc;
+    beforeEach(() => {
+        rpc = createLocalhostSolanaRpc();
+    });
+
+    it('query with types', async () => {
+        expect.assertions(1);
+
+        const masterEditionAddress = 'B2Srva38aD8bWpjghkU7jKFUqT1Y4KB2ejAnsJbP2ibA';
+
+        // Define custom type definitions for the GraphQL schema.
+        const customTypeDefs = /* GraphQL */ `
+            # A Solana Master Edition NFT.
+            type NftMasterEdition {
+                address: Address
+                metadata: Account
+                mint: Account
+            }
+
+            # Query to retrieve a Solana Master Edition NFT.
+            type Query {
+                masterEdition(address: Address!): NftMasterEdition
+            }
+        `;
+
+        // Define custom resolvers for the GraphQL schema.
+        const customTypeResolvers = {
+            // Resolver for the custom `NftMasterEdition` type.
+            NftMasterEdition: {
+                metadata: resolveAccount('metadata'),
+                mint: resolveAccount('mint'),
+            },
+        };
+
+        // Define custom queries for the GraphQL schema.
+        const customQueryResolvers = {
+            // Query to retrieve a Solana Master Edition NFT.
+            masterEdition: () => {
+                return {
+                    // Arbitrary address.
+                    address: masterEditionAddress,
+                    // See scripts/fixtures/gpa1.json.
+                    metadata: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
+                    // See scripts/fixtures/spl-token-mint-account.json.
+                    mint: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                };
+            },
+        };
+
+        // Create the RPC-GraphQL client with the custom type definitions and
+        // resolvers.
+        const rpcGraphQL = createRpcGraphQL(rpc, {
+            queryResolvers: customQueryResolvers,
+            typeDefs: customTypeDefs,
+            typeResolvers: customTypeResolvers,
+        });
+
+        // Create a test query for the custom `masterEdition` query.
+        const source = /* GraphQL */ `
+            query ($masterEditionAddress: Address!) {
+                masterEdition(address: $masterEditionAddress) {
+                    address
+                    metadata {
+                        address
+                        lamports
+                    }
+                    mint {
+                        address
+                        lamports
+                        ownerProgram {
+                            address
+                        }
+                        ... on MintAccount {
+                            decimals
+                            supply
+                        }
+                    }
+                }
+            }
+        `;
+
+        // Execute the test query.
+        const result = await rpcGraphQL.query(source, {
+            masterEditionAddress,
+        });
+
+        // Assert the custom type definitions and resolvers were accepted and
+        // the query was successful.
+        expect(result).toMatchObject({
+            data: {
+                masterEdition: {
+                    address: masterEditionAddress,
+                    metadata: {
+                        address: 'CcYNb7WqpjaMrNr7B1mapaNfWctZRH7LyAjWRLBGt1Fk',
+                        lamports: expect.any(BigInt),
+                    },
+                    mint: {
+                        address: 'Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr',
+                        decimals: expect.any(Number),
+                        lamports: expect.any(BigInt),
+                        ownerProgram: {
+                            address: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
+                        },
+                        supply: expect.any(String),
+                    },
+                },
+            },
+        });
+    });
+});

--- a/packages/rpc-graphql/src/index.ts
+++ b/packages/rpc-graphql/src/index.ts
@@ -12,17 +12,51 @@ export interface RpcGraphQL {
     ): ReturnType<typeof graphql>;
 }
 
-export function createRpcGraphQL(
-    rpc: Parameters<typeof createSolanaGraphQLContext>[0],
-    config?: Partial<Parameters<typeof createSolanaGraphQLContext>[1]>,
-): RpcGraphQL {
+type Config = {
+    /**
+     * Maximum number of acceptable bytes to waste before splitting two
+     * `dataSlice` requests into two requests.
+     */
+    maxDataSliceByteRange?: number;
+    /**
+     * Maximum number of accounts to fetch in a single batch.
+     * See https://docs.solana.com/api/http#getmultipleaccounts.
+     */
+    maxMultipleAccountsBatchSize?: number;
+    /**
+     * Resolvers for custom queries to extend the default queries.
+     */
+    queryResolvers?: Parameters<typeof makeExecutableSchema>[0]['resolvers'];
+    /**
+     * Custom type definitions to extend the default type definitions in
+     * the GraphQL schema.
+     *
+     * Note: custom type definitions may not override existing type
+     * definitions, but may implement existing interfaces.
+     *
+     * These type definitions should correspond to any custom resolvers
+     * provided in `resolvers`.
+     */
+    typeDefs?: Parameters<typeof makeExecutableSchema>[0]['typeDefs'];
+    /**
+     * Custom type resolvers to extend the default resolvers.
+     *
+     * These resolvers should correspond to any custom type definitions
+     * provided in `typeDefs`.
+     */
+    typeResolvers?: Parameters<typeof makeExecutableSchema>[0]['resolvers'];
+};
+
+export function createRpcGraphQL(rpc: Parameters<typeof createSolanaGraphQLContext>[0], config?: Config): RpcGraphQL {
+    const { maxDataSliceByteRange, maxMultipleAccountsBatchSize, queryResolvers, typeResolvers, typeDefs } =
+        config ?? {};
     const rpcGraphQLConfig = {
-        maxDataSliceByteRange: config?.maxDataSliceByteRange ?? 200,
-        maxMultipleAccountsBatchSize: config?.maxMultipleAccountsBatchSize ?? 100,
+        maxDataSliceByteRange: maxDataSliceByteRange ?? 200,
+        maxMultipleAccountsBatchSize: maxMultipleAccountsBatchSize ?? 100,
     };
     const schema = makeExecutableSchema({
-        resolvers: createSolanaGraphQLResolvers(),
-        typeDefs: createSolanaGraphQLTypeDefs(),
+        resolvers: createSolanaGraphQLResolvers({ queryResolvers, typeResolvers }),
+        typeDefs: createSolanaGraphQLTypeDefs({ typeDefs }),
     });
     return {
         async query(source, variableValues?) {
@@ -36,3 +70,8 @@ export function createRpcGraphQL(
         },
     };
 }
+
+// Export resolvers to be used to build custom resolvers.
+export { resolveAccount } from './resolvers/account';
+export { resolveBlock } from './resolvers/block';
+export { resolveTransaction } from './resolvers/transaction';

--- a/packages/rpc-graphql/src/resolvers/index.ts
+++ b/packages/rpc-graphql/src/resolvers/index.ts
@@ -7,13 +7,25 @@ import { rootResolvers } from './root';
 import { transactionResolvers } from './transaction';
 import { typeTypeResolvers } from './types';
 
-export function createSolanaGraphQLResolvers(): Parameters<typeof makeExecutableSchema>[0]['resolvers'] {
+type Resolvers = Parameters<typeof makeExecutableSchema>[0]['resolvers'];
+
+export function createSolanaGraphQLResolvers({
+    queryResolvers,
+    typeResolvers,
+}: {
+    queryResolvers?: Resolvers;
+    typeResolvers?: Resolvers;
+}): Resolvers {
     return {
+        Query: {
+            ...queryResolvers,
+            ...rootResolvers,
+        },
         ...accountResolvers,
         ...blockResolvers,
         ...instructionResolvers,
-        ...rootResolvers,
         ...transactionResolvers,
+        ...typeResolvers,
         ...typeTypeResolvers,
     };
 }

--- a/packages/rpc-graphql/src/resolvers/root.ts
+++ b/packages/rpc-graphql/src/resolvers/root.ts
@@ -6,10 +6,8 @@ import { resolveProgramAccounts } from './program-accounts';
 import { resolveTransaction } from './transaction';
 
 export const rootResolvers: Parameters<typeof makeExecutableSchema>[0]['resolvers'] = {
-    Query: {
-        account: resolveAccount(),
-        block: resolveBlock(),
-        programAccounts: resolveProgramAccounts(),
-        transaction: resolveTransaction(),
-    },
+    account: resolveAccount(),
+    block: resolveBlock(),
+    programAccounts: resolveProgramAccounts(),
+    transaction: resolveTransaction(),
 };

--- a/packages/rpc-graphql/src/schema/index.ts
+++ b/packages/rpc-graphql/src/schema/index.ts
@@ -1,3 +1,5 @@
+import type { makeExecutableSchema } from '@graphql-tools/schema';
+
 import { accountTypeDefs } from './account';
 import { blockTypeDefs } from './block';
 import { instructionTypeDefs } from './instruction';
@@ -5,6 +7,19 @@ import { rootTypeDefs } from './root';
 import { transactionTypeDefs } from './transaction';
 import { typeTypeDefs } from './types';
 
-export function createSolanaGraphQLTypeDefs() {
-    return [accountTypeDefs, blockTypeDefs, instructionTypeDefs, rootTypeDefs, typeTypeDefs, transactionTypeDefs];
+type TypeDefs = Parameters<typeof makeExecutableSchema>[0]['typeDefs'];
+
+export function createSolanaGraphQLTypeDefs({ typeDefs }: { typeDefs?: TypeDefs }): TypeDefs {
+    const schemaTypeDefs = [
+        accountTypeDefs,
+        blockTypeDefs,
+        instructionTypeDefs,
+        rootTypeDefs,
+        typeTypeDefs,
+        transactionTypeDefs,
+    ] as TypeDefs[];
+    if (typeDefs) {
+        schemaTypeDefs.push(typeDefs);
+    }
+    return schemaTypeDefs;
 }


### PR DESCRIPTION
#### Problem
Many projects who wish to use the RPC-GraphQL resolver library may wish to 
extend the default schema, which is designed around the 
[Solana JSON-RPC API](https://solana.com/docs/rpc). Currently, the library does 
not allow for such customization.

There's currently no way for developers to add additional queries, types, and 
resolvers to the GraphQL client, making extending this powerful library very 
difficult.

#### Summary of Changes
Introduce three optional configurations for `createRpcGraphQL`.

- `queryResolvers`: Custom root query resolvers.
- `typeResolvers`: Custom type definition resolvers.
- `typeDefs`: Custom GraphQL schema type definitions.

I've also made the default type resolvers, which drive the batch loader, 
availably publicly to downstream users (`resolveAccount`, `resolveBlock`, 
`resolveTransaction`).

Lastly, I've added a test demonstrating how one might define custom types, 
resolvers, and a custom query and provide those to the GraphQL RPC client.

**Note:** This should be the first in a series of changes to allow schema 
extension. While the change proposed herein enables a wide range of possible 
extended functionality, there are a few limitations. One such limitation is the 
lack of ability to provide custom codec-based resolvers to convert `base58` or 
`base64` encoded accounts/instructions to custom decoded types.

Ref: https://github.com/solana-labs/solana-web3.js/issues/2614