### PR TITLE
Make __DEV__ robust to environments without process.env

### DIFF
--- a/packages/build-scripts/env-shim.ts
+++ b/packages/build-scripts/env-shim.ts
@@ -1,2 +1,10 @@
-// Clever obfuscation to prevent the build system from inlining the value of `NODE_ENV`
-export const __DEV__ = /* @__PURE__ */ (() => (process as any)['en' + 'v'].NODE_ENV === 'development')();
+function isDevelopment() {
+    if (typeof process === 'object' && process.env) {
+        // We use `'en' + 'v'` to prevent the build system from inlining the value of `NODE_ENV`
+        return (process as any)['en' + 'v'].NODE_ENV === 'development';
+    }
+    // if no process.env, use dev mode
+    return true;
+}
+
+export const __DEV__ = /* @__PURE__ */ isDevelopment();


### PR DESCRIPTION
This PR updates the logic used to define `__DEV__` in the build scripts env-shim, so that if `process.env` doesn't exist  in the environment where we end up running doesn't exist, then it returns true instead of throwing a runtime error

The generated code in eg `packages/errors/dist/index.browser.cjs` is now:

```js
// ../build-scripts/env-shim.ts
function isDevelopment() {
  if (typeof process === "object" && process.env) {
    return process["env"].NODE_ENV === "development";
  }
  return true;
}
var __DEV__ = /* @__PURE__ */ isDevelopment();
```

Where previously it was:
```js
// ../build-scripts/env-shim.ts
var __DEV__ = /* @__PURE__ */ (() => process["env"].NODE_ENV === "development")();
```