### PR TITLE
update test validator for mainnet-beta v1.18

### DIFF
--- a/scripts/get-latest-validator-release-version.sh
+++ b/scripts/get-latest-validator-release-version.sh
@@ -2,7 +2,7 @@
 (
     set -e
     version=$(node -e \
-      'fetch("https://api.github.com/repos/anza-xyz/agave/releases").then(res => res.json().then(rs => rs.filter(r => !r.prerelease && r.tag_name.startsWith("v1.17."))).then(x => console.log(x[0].tag_name)));'
+      'fetch("https://api.github.com/repos/anza-xyz/agave/releases").then(res => res.json().then(rs => rs.filter(r => !r.prerelease && r.tag_name.startsWith("v1.18."))).then(x => console.log(x[0].tag_name)));'
     )
     if [ -z $version ]; then
       exit 3


### PR DESCRIPTION
Solana v1.18.15 is officially recommended for mainnet-beta, and has reached
supermajority adoption.

This PR updates Web3.js to use the test validator for 1.18, matching the running
version for mainnet-beta.