### PR TITLE
A utility that makes an `AsyncIterator` interruptible

### DIFF
--- a/.changeset/tender-bags-boil.md
+++ b/.changeset/tender-bags-boil.md
@@ -1,0 +1,5 @@
+---
+'@solana/async': patch
+---
+
+Added a utility that you can use to make an `AsyncIterator` interruptible, even if prior calls to `next()` are still pending

--- a/packages/async/README.md
+++ b/packages/async/README.md
@@ -18,8 +18,65 @@ This package contains utilities for working with asynchronous values like promis
 
 ## Types
 
-TODO
+### `InterruptibleAsyncIterator<T, TReturn, TNext>`
+
+Represents an `AsyncIterator` that can be interrupted abruptly by calling its `return` function. This type is mostly identical to `AsyncIterator` with one difference. Because interruptible iterators do not wait for the inner iterator's `return` function to resolve, the return value of an interruptible iterator may be `undefined`.
+
+The type of an interruptible iterator's `return` function therefore includes `undefined` in its return type:
+
+```ts
+type ReturnFn = (value?: PromiseLike<TReturn> | TReturn) => Promise<
+    IteratorResult<
+        T,
+        // Add in `undefined` here, to cover the interruption case.
+        TReturn | undefined
+    >
+>;
+```
 
 ## Functions
 
-TODO
+### `createInterruptibleAsyncIterator(innerIterator)`
+
+Given an `AsyncIterator`, returns an `InterruptibleAsyncIterator`. Interruptible iterators are designed so that any pending iteration of the inner iterator be abruptly interrupted by a call to `return` on the outer iterator. All pending calls to `next` will return `undefined` upon interruption, unconditionally and immediately.
+
+Features:
+
+-   Calling `return` will immediately cause pending calls to `next` or `throw` to resolve
+-   Calling `return` will also call `return` on the inner iterator so that it can run cleanup
+-   Calling `throw` will delegate to the inner iterator's `throw` if it is defined
+-   This iterator will terminate if ever the inner iterator returns an `IteratorReturnResult`
+-   This iterator will terminate if the inner iterator's `next` or `throw` method rejects
+-   Once terminated, this iterator will no longer forward calls to the inner iterator
+-   This iterator will return a clone of the terminal result via `next`, `return`, and `throw`
+
+Interruptible async iterators can be useful when the promises vended by their inner iterator might pend indefinitely. Calling `return` on an interruptible iterator signals to its consumers to return early while still telling the inner iterator that it's time to run cleanup.
+
+```ts
+import { createInterruptibleAsyncIterator } from '@solana/async';
+
+const innerIterator = {
+    async next() {
+        await new Promise(resolve => {
+            timerId = setTimeout(resolve, 3000);
+        });
+        console.log('timer fired');
+        return { done: false, value: 123 };
+    },
+    return() {
+        console.log('running cleanup in inner `return`');
+        clearTimeout(timerId);
+        return Promise.resolve({ done: true, value: undefined } as const);
+    },
+};
+const interruptibleIterator = createInterruptibleAsyncIterator(innerIterator);
+
+interruptibleIterator.next().then(r => console.log('next result', r));
+interruptibleIterator.return().then(r => console.log('return result', r));
+
+// LOGS IMMEDIATELY
+// running cleanup in inner `return`
+// return result { done: true, value: undefined }
+// next result { done: true, value: undefined }
+// ...never logs 'timer fired'...
+```

--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -65,6 +65,12 @@
     "engine": {
         "node": ">=17.4"
     },
+    "dependencies": {
+        "@solana/promises": "workspace:*"
+    },
+    "devDependencies": {
+        "@solana/test-matchers": "workspace:*"
+    },
     "peerDependencies": {
         "typescript": ">=5"
     },

--- a/packages/async/src/__tests__/interruptible-test.ts
+++ b/packages/async/src/__tests__/interruptible-test.ts
@@ -1,0 +1,455 @@
+import '@solana/test-matchers/toBeFrozenObject';
+
+import { createInterruptibleAsyncIterator, InterruptibleAsyncIterator } from '../interruptible';
+
+describe('createInterruptibleAsyncIterator', () => {
+    let innerIterator: AsyncIterator<void>;
+    let mockInnerNext: jest.Mock<Promise<IteratorResult<void>>>;
+    beforeEach(() => {
+        mockInnerNext = jest.fn().mockResolvedValue({ done: false, value: 42 });
+        innerIterator = {
+            next: mockInnerNext,
+        };
+    });
+    it('does not poll the inner iterator upon construction', () => {
+        createInterruptibleAsyncIterator(innerIterator);
+        expect(mockInnerNext).not.toHaveBeenCalled();
+    });
+    it('omits non-iterator properties from the original iterator', () => {
+        function reset() {}
+        const iterator = createInterruptibleAsyncIterator({ ...innerIterator, reset });
+        expect(iterator).not.toHaveProperty('reset', reset);
+    });
+    it('returns a frozen object', () => {
+        const iterator = createInterruptibleAsyncIterator(innerIterator);
+        expect(iterator).toBeFrozenObject();
+    });
+});
+
+describe('an interruptible `AsyncIterator`', () => {
+    let interruptibleIterator: InterruptibleAsyncIterator<42, 'return', 'next'>;
+    let mockInnerNext: jest.Mock<Promise<IteratorResult<42, 'return'>>, ['next']>;
+    beforeEach(() => {
+        mockInnerNext = jest.fn().mockResolvedValue({ done: false, value: 42 });
+        interruptibleIterator = createInterruptibleAsyncIterator({
+            next: mockInnerNext,
+        });
+    });
+    it('forwards calls to `next()` to the inner iterator', () => {
+        interruptibleIterator.next('next');
+        expect(mockInnerNext).toHaveBeenCalledWith('next');
+    });
+    describe('given that the next value will reject on the next call', () => {
+        beforeEach(() => {
+            mockInnerNext.mockRejectedValueOnce('o no');
+        });
+        it('rejects with that value when `next()` is called', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.next('next')).rejects.toBe('o no');
+        });
+        describe('after the call to `next()` rejects', () => {
+            beforeEach(async () => {
+                await interruptibleIterator.next('next').catch(() => {});
+            });
+            it('does not forward subsequent calls to `next()` to the inner iterator', () => {
+                mockInnerNext.mockClear();
+                interruptibleIterator.next('next');
+                expect(mockInnerNext).not.toHaveBeenCalled();
+            });
+            it('returns a terminal result on subsequent calls to `next()`', async () => {
+                expect.assertions(1);
+                await expect(interruptibleIterator.next('next')).resolves.toStrictEqual({
+                    done: true,
+                    value: undefined,
+                });
+            });
+        });
+    });
+    describe('given that the next value will resolve', () => {
+        let expectedResult: IteratorYieldResult<42>;
+        beforeEach(() => {
+            expectedResult = { done: false, value: 42 };
+            mockInnerNext.mockResolvedValue(expectedResult);
+        });
+        it('resolves to that exact result when `next()` is called', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.next('next')).resolves.toBe(expectedResult);
+        });
+    });
+    describe('given that the next value will resolve a terminal result', () => {
+        let terminalResult: IteratorReturnResult<'return'>;
+        beforeEach(() => {
+            terminalResult = { done: true, value: 'return' };
+            mockInnerNext.mockResolvedValue(terminalResult);
+        });
+        it('resolves to that result when `next()` is called', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.next('next')).resolves.toBe(terminalResult);
+        });
+        describe('after a successful call to `next()`', () => {
+            beforeEach(async () => {
+                await interruptibleIterator.next('next');
+            });
+            it('does not forward subsequent calls to `next()` to the inner iterator`', () => {
+                mockInnerNext.mockClear();
+                interruptibleIterator.next('next');
+                expect(mockInnerNext).not.toHaveBeenCalled();
+            });
+            it('resolves subsequent calls to `next()` with something that equals the terminal result', async () => {
+                expect.assertions(1);
+                await expect(interruptibleIterator.next('next')).resolves.toStrictEqual(terminalResult);
+            });
+            it('resolves subsequent calls to `next()` with something that is not exactly the terminal result', async () => {
+                expect.assertions(1);
+                await expect(interruptibleIterator.next('next')).resolves.not.toBe(terminalResult);
+            });
+        });
+    });
+});
+
+describe('an interruptible `AsyncIterator` whose inner iterator implements `return()`', () => {
+    let interruptibleIterator: InterruptibleAsyncIterator<42, 'return', 'next'>;
+    let mockInnerNext: jest.Mock<Promise<IteratorResult<42, 'return'>>, ['next']>;
+    let mockInnerReturn: jest.Mock<Promise<IteratorResult<42, 'return'>>, ['return']>;
+    beforeEach(() => {
+        mockInnerNext = jest.fn().mockResolvedValue({ done: false, value: 42 });
+        mockInnerReturn = jest.fn().mockResolvedValue({ done: true, value: 'return' });
+        interruptibleIterator = createInterruptibleAsyncIterator({
+            next: mockInnerNext,
+            return: mockInnerReturn,
+        });
+    });
+    it('calls `return()` on the inner iterator when calling `return()`', () => {
+        interruptibleIterator.return('return');
+        expect(mockInnerReturn).toHaveBeenCalledWith('return');
+    });
+    it('resolves to the terminal result with that value when calling `return()`', async () => {
+        expect.assertions(1);
+        await expect(interruptibleIterator.return('return')).resolves.toStrictEqual({
+            done: true,
+            value: 'return',
+        });
+    });
+    it('resolves different results on subsequent identical calls to `return()`', async () => {
+        expect.assertions(1);
+        const [returnResultA, returnResultB] = await Promise.all([
+            interruptibleIterator.return('return'),
+            interruptibleIterator.return('return'),
+        ]);
+        expect(returnResultA).not.toBe(returnResultB);
+    });
+    it("does not wait for the inner iterator's `return()` method to resolve before resolving", async () => {
+        expect.assertions(1);
+        mockInnerReturn.mockReturnValue(
+            new Promise(() => {
+                /* never resolves */
+            }),
+        );
+        await expect(interruptibleIterator.return('return').then(() => 'done')).resolves.toBe('done');
+    });
+    it("does not resolve to the value returned by the inner iterator's `return()` method", async () => {
+        expect.assertions(1);
+        const innerReturnResult = { done: true, value: 'return' } as const;
+        mockInnerReturn.mockResolvedValue(innerReturnResult);
+        await expect(interruptibleIterator.return('return')).resolves.not.toBe(innerReturnResult);
+    });
+    describe('when `return()` has already been called', () => {
+        beforeEach(async () => {
+            await interruptibleIterator.return('return');
+        });
+        it('does not forward calls to `next()` to the inner iterator', () => {
+            mockInnerNext.mockClear();
+            interruptibleIterator.next('next');
+            expect(mockInnerNext).not.toHaveBeenCalled();
+        });
+        it('does not forward calls to `return()` to the inner iterator', () => {
+            mockInnerReturn.mockClear();
+            interruptibleIterator.return('return');
+            expect(mockInnerReturn).not.toHaveBeenCalled();
+        });
+        it('resolves the terminal result on subsequent calls to `next()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.next('next')).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+    });
+    describe('given that the last call to `next()` pends indefinitely', () => {
+        beforeEach(() => {
+            mockInnerNext.mockReturnValue(
+                new Promise(() => {
+                    /* never resolve */
+                }),
+            );
+        });
+        it('resolves to the terminal result with that value immediately when `return()` is called', async () => {
+            expect.assertions(2);
+            const nextPromise = interruptibleIterator.next('next');
+            await expect(Promise.race(['pending', nextPromise])).resolves.toBe('pending');
+            interruptibleIterator.return('return');
+            await expect(nextPromise).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+    });
+    describe('given that the last call to `next()` resolved to a terminal result', () => {
+        let terminalResult: IteratorReturnResult<'return'>;
+        beforeEach(async () => {
+            terminalResult = { done: true, value: 'return' };
+            mockInnerNext.mockResolvedValue(terminalResult);
+            await interruptibleIterator.next('next');
+        });
+        it('returns something equal to that value on subsequent calls to `return()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.return('return')).resolves.toStrictEqual(terminalResult);
+        });
+        it('returns something that is not exactly that value on subsequent calls to `return()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.return('return')).resolves.not.toBe(terminalResult);
+        });
+        it('does not forward subsequent calls to `next()` to the inner iterator', () => {
+            mockInnerNext.mockClear();
+            interruptibleIterator.next('next');
+            expect(mockInnerNext).not.toHaveBeenCalled();
+        });
+        it('does not forward subsequent calls to `return()` to the inner iterator', () => {
+            mockInnerReturn.mockClear();
+            interruptibleIterator.return('return');
+            expect(mockInnerReturn).not.toHaveBeenCalled();
+        });
+    });
+});
+
+describe('an interruptible `AsyncIterator` whose inner iterator does not implement `return()`', () => {
+    let interruptibleIterator: InterruptibleAsyncIterator<42, 'return', 'next'>;
+    let mockInnerNext: jest.Mock<Promise<IteratorResult<42, 'return'>>, ['next']>;
+    beforeEach(() => {
+        mockInnerNext = jest.fn().mockResolvedValue({ done: false, value: 42 });
+        interruptibleIterator = createInterruptibleAsyncIterator({
+            next: mockInnerNext,
+        });
+    });
+    it('resolves to the terminal result with that value when `return()` is called', async () => {
+        expect.assertions(1);
+        await expect(interruptibleIterator.return('return')).resolves.toStrictEqual({
+            done: true,
+            value: 'return',
+        });
+    });
+    it('resolves different results on subsequent calls to `return()`', async () => {
+        expect.assertions(1);
+        const [returnResultA, returnResultB] = await Promise.all([
+            interruptibleIterator.return('return'),
+            interruptibleIterator.return('return'),
+        ]);
+        expect(returnResultA).not.toBe(returnResultB);
+    });
+    describe('when `return()` has already been called', () => {
+        beforeEach(async () => {
+            await interruptibleIterator.return('return');
+        });
+        it('does not forward calls to `next()` to the inner iterator', () => {
+            mockInnerNext.mockClear();
+            interruptibleIterator.next('next');
+            expect(mockInnerNext).not.toHaveBeenCalled();
+        });
+        it('resolves to the terminal result with that value on subsequent calls to `next()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.next('next')).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+    });
+    describe('given that the last call to `next()` pends indefinitely', () => {
+        beforeEach(() => {
+            mockInnerNext.mockReturnValue(
+                new Promise(() => {
+                    /* never resolve */
+                }),
+            );
+        });
+        it('resolves to the terminal result with that value immediately when `return()` is called', async () => {
+            expect.assertions(2);
+            const nextPromise = interruptibleIterator.next('next');
+            await expect(Promise.race(['pending', nextPromise])).resolves.toBe('pending');
+            interruptibleIterator.return('return');
+            await expect(nextPromise).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+    });
+    describe('given that the last call to `next()` resolved to a terminal result', () => {
+        beforeEach(async () => {
+            mockInnerNext.mockResolvedValue({ done: true, value: 'return' });
+            await interruptibleIterator.next('next');
+        });
+        it('returns that value on subsequent calls to `next()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.next('next')).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+        it('returns that value on subsequent calls to `return()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.return('return')).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+        it('does not forward subsequent calls to `next()` to the inner iterator', () => {
+            mockInnerNext.mockClear();
+            interruptibleIterator.next('next');
+            expect(mockInnerNext).not.toHaveBeenCalled();
+        });
+    });
+});
+
+describe('an interruptible `AsyncIterator` whose inner iterator implements `throw()`', () => {
+    let interruptibleIterator: InterruptibleAsyncIterator<42, 'return', 'next'> & {
+        throw(e: 666): Promise<IteratorResult<42, 'return'>>;
+    };
+    let mockInnerNext: jest.Mock<Promise<IteratorResult<42, 'return'>>, ['next']>;
+    let mockInnerThrow: jest.Mock<Promise<IteratorResult<42, 'return'>>>;
+    beforeEach(() => {
+        mockInnerNext = jest.fn().mockResolvedValue({ done: false, value: 42 });
+        mockInnerThrow = jest.fn().mockResolvedValue({ done: false, value: 42 });
+        interruptibleIterator = createInterruptibleAsyncIterator({
+            next: mockInnerNext,
+            throw: mockInnerThrow,
+        });
+    });
+    it('forwards calls to `throw()` to the inner iterator', () => {
+        interruptibleIterator.throw(666);
+        expect(mockInnerThrow).toHaveBeenCalledWith(666);
+    });
+    describe('given that the last call to `throw()` rejected', () => {
+        beforeEach(() => {
+            mockInnerThrow.mockRejectedValueOnce('o no');
+        });
+        it('rejects with that value when `throw()` is called', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.throw(666)).rejects.toBe('o no');
+        });
+        describe('after the call to `throw()` rejects', () => {
+            beforeEach(async () => {
+                await interruptibleIterator.throw(666).catch(() => {});
+            });
+            it('does not forward subsequent calls to `next()` to the inner iterator', () => {
+                mockInnerNext.mockClear();
+                interruptibleIterator.next('next');
+                expect(mockInnerNext).not.toHaveBeenCalled();
+            });
+            it('does not forward subsequent calls to `throw()` to the inner iterator', () => {
+                mockInnerThrow.mockClear();
+                interruptibleIterator.throw(666);
+                expect(mockInnerThrow).not.toHaveBeenCalled();
+            });
+            it('returns a terminal result on subsequent calls to `next()`', async () => {
+                expect.assertions(1);
+                await expect(interruptibleIterator.next('next')).resolves.toStrictEqual({
+                    done: true,
+                    value: undefined,
+                });
+            });
+            it('returns a terminal result on subsequent calls to `throw()`', async () => {
+                expect.assertions(1);
+                await expect(interruptibleIterator.throw(666)).resolves.toStrictEqual({
+                    done: true,
+                    value: undefined,
+                });
+            });
+        });
+    });
+    describe('given that the last call to `throw()` pends indefinitely', () => {
+        beforeEach(() => {
+            mockInnerThrow.mockReturnValue(
+                new Promise(() => {
+                    /* never resolve */
+                }),
+            );
+        });
+        it('resolves to the terminal result immediately when `return()` is called', async () => {
+            expect.assertions(2);
+            const throwPromise = interruptibleIterator.throw(666);
+            await expect(Promise.race(['pending', throwPromise])).resolves.toBe('pending');
+            interruptibleIterator.return('return');
+            await expect(throwPromise).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+    });
+    describe('given that the last call to `throw()` resolved to a terminal result', () => {
+        beforeEach(async () => {
+            mockInnerThrow.mockResolvedValue({ done: true, value: 'return' });
+            await interruptibleIterator.throw(666);
+        });
+        it('returns that value on subsequent calls to `next()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.next('next')).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+        it('returns that value on subsequent calls to `return()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.return('return')).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+        it('returns that value on subsequent calls to `throw()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.throw(666)).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+        it('does not forward subsequent calls to `next()` to the inner iterator', () => {
+            mockInnerNext.mockClear();
+            interruptibleIterator.next('next');
+            expect(mockInnerNext).not.toHaveBeenCalled();
+        });
+        it('does not forward subsequent calls to `throw()` to the inner iterator', () => {
+            mockInnerThrow.mockClear();
+            interruptibleIterator.throw(666);
+            expect(mockInnerThrow).not.toHaveBeenCalled();
+        });
+    });
+    describe('when `return()` has already been called', () => {
+        beforeEach(async () => {
+            await interruptibleIterator.return('return');
+        });
+        it('does not forward calls to `throw()` to the inner iterator', () => {
+            mockInnerThrow.mockClear();
+            interruptibleIterator.throw(666);
+            expect(mockInnerThrow).not.toHaveBeenCalled();
+        });
+        it('resolves the terminal result on subsequent calls to `throw()`', async () => {
+            expect.assertions(1);
+            await expect(interruptibleIterator.throw(666)).resolves.toStrictEqual({
+                done: true,
+                value: 'return',
+            });
+        });
+    });
+});
+
+describe('an interruptible `AsyncIterator` whose inner iterator does not implement `throw()`', () => {
+    let interruptibleIterator: InterruptibleAsyncIterator<42, 'return', 'next'>;
+    let mockInnerNext: jest.Mock<Promise<IteratorResult<42, 'return'>>, ['next']>;
+    beforeEach(() => {
+        mockInnerNext = jest.fn().mockResolvedValue({ done: false, value: 42 });
+        interruptibleIterator = createInterruptibleAsyncIterator({
+            next: mockInnerNext,
+        });
+    });
+    it('has no `throw()` method', () => {
+        expect(interruptibleIterator).not.toHaveProperty('throw');
+    });
+});

--- a/packages/async/src/__typetests__/interruptible-typetest.ts
+++ b/packages/async/src/__typetests__/interruptible-typetest.ts
@@ -1,0 +1,59 @@
+import { createInterruptibleAsyncIterator } from '../interruptible';
+
+// [DESCRIBE] createInterruptibleAsyncIterator
+{
+    // It returns an `AsyncIterator` with an identical type except for the return type which must include `undefined`
+    {
+        const originalIterator = null as unknown as AsyncIterator<string, 42, [true]>;
+        createInterruptibleAsyncIterator(originalIterator) satisfies AsyncIterator<
+            /* T */ string,
+            // The addition of `undefined` here represents what would be returned in the
+            // interruption scenario. Interruptions always return `undefined` as the final value.
+            /* TReturn */ 42 | undefined,
+            /* TNext */ [true]
+        >;
+        // @ts-expect-error `TReturn` here must include `undefined`.
+        createInterruptibleAsyncIterator(originalIterator) satisfies AsyncIterator<
+            /* T */ string,
+            /* TReturn */ 42,
+            /* TNext */ [true]
+        >;
+    }
+
+    // It strips out properties from the source object that are not part of the iterator protocol.
+    {
+        const originalIterator = null as unknown as AsyncIterator<unknown> & { reset(): void };
+        // @ts-expect-error The `reset` method should not be found on the return value.
+        createInterruptibleAsyncIterator(originalIterator) satisfies { reset(): void };
+    }
+
+    // It resolves to `TReturn` when a value is supplied to `return()`
+    {
+        const originalIterator = null as unknown as AsyncIterator<unknown, 42>;
+        const interruptibleIterator = createInterruptibleAsyncIterator(originalIterator);
+        interruptibleIterator.return!(42) satisfies Promise<IteratorResult<unknown, 42>>;
+        interruptibleIterator.return!(Promise.resolve(42)) satisfies Promise<IteratorResult<unknown, 42>>;
+    }
+
+    // It resolves to `TReturn | undefined` when no value is supplied to `return()`
+    {
+        const originalIterator = null as unknown as AsyncIterator<unknown, 42>;
+        const interruptibleIterator = createInterruptibleAsyncIterator(originalIterator);
+        interruptibleIterator.return!() satisfies Promise<IteratorResult<unknown, 42 | undefined>>;
+    }
+
+    // It exposes the original iterator's throw method
+    {
+        const originalIterator = null as unknown as Omit<AsyncIterator<string, 42>, 'throw'> & {
+            throw(e?: 666): Promise<IteratorResult<string, 42>>;
+        };
+        createInterruptibleAsyncIterator(originalIterator).throw satisfies (typeof originalIterator)['throw'];
+    }
+
+    // It exposes no `throw()` method when the original iterator has none
+    {
+        const originalIterator = null as unknown as Omit<AsyncIterator<unknown>, 'throw'>;
+        // @ts-expect-error No `throw` function should be found on the return value.
+        createInterruptibleAsyncIterator(originalIterator) satisfies { throw: () => void };
+    }
+}

--- a/packages/async/src/index.ts
+++ b/packages/async/src/index.ts
@@ -1,1 +1,1 @@
-export {};
+export * from './interruptible';

--- a/packages/async/src/interruptible.ts
+++ b/packages/async/src/interruptible.ts
@@ -1,0 +1,133 @@
+import { safeRace } from '@solana/promises';
+
+export type InterruptibleAsyncIterator<T, TReturn = unknown, TNext = undefined> = {
+    next(...args: [] | [TNext]): Promise<
+        IteratorResult<
+            T,
+            // Add in `undefined` here, to cover the interruption case.
+            TReturn | undefined
+        >
+    >;
+    return(value: PromiseLike<TReturn> | TReturn): Promise<IteratorResult<T, TReturn>>;
+    return(value?: PromiseLike<TReturn> | TReturn): Promise<
+        IteratorResult<
+            T,
+            // Add in `undefined` here, to cover the interruption case.
+            TReturn | undefined
+        >
+    >;
+};
+
+type MakeAsyncIteratorInterruptible<TIterator extends AsyncIterator<unknown, unknown, unknown>> =
+    InterruptibleAsyncIterator<
+        /* T */ Extract<Awaited<ReturnType<TIterator['next']>>, { done?: false }>['value'],
+        /* TReturn */ Extract<Awaited<ReturnType<TIterator['next']>>, { done: true }>['value'],
+        /* TNext */ Parameters<TIterator['next']>[0]
+    > &
+        ('throw' extends keyof TIterator ? Pick<TIterator, 'throw'> : Record<string, never>);
+
+function shallowClone<T extends object>(value: T): T {
+    return { ...value };
+}
+
+/**
+ * This interruptible iterator is designed so that any pending iteration of the inner iterator be
+ * abruptly interrupted by a call to `return` on the outer iterator. All pending calls to `next`
+ * will return `undefined` upon interruption, unconditionally and immediately.
+ *
+ * Features:
+ *
+ *     - Calling `return` will immediately cause pending calls to `next` or `throw` to resolve
+ *     - Calling `return` will also call `return` on the inner iterator so that it can run cleanup
+ *     - Calling `throw` will delegate to the inner iterator's `throw` if it is defined
+ *     - This iterator will terminate if ever the inner iterator returns an `IteratorReturnResult`
+ *     - This iterator will terminate if the inner iterator's `next` or `throw` method rejects
+ *     - Once terminated, this iterator will no longer forward calls to the inner iterator
+ *     - This iterator will return a clone of the terminal result via `next`, `return`, and `throw`
+ *
+ * Interruptible async iterators can be useful when the promises vended by their inner iterator
+ * might pend indefinitely. Calling `return` on an interruptible iterator signals to its consumers
+ * to return early while still telling the inner iterator that it's time to run cleanup.
+ */
+export function createInterruptibleAsyncIterator<TIterator extends AsyncIterator<unknown, unknown, unknown>>(
+    innerIterator: TIterator,
+): Readonly<MakeAsyncIteratorInterruptible<TIterator>> {
+    let didTerminate = false;
+    let terminateIterator!: <TReturn>(terminalValue?: PromiseLike<TReturn> | TReturn) => void;
+    const terminalResponsePromise = new Promise<IteratorReturnResult<unknown>>(resolve => {
+        terminateIterator = terminalValue => {
+            if (didTerminate) {
+                return;
+            }
+            didTerminate = true;
+            resolve(
+                terminalValue && typeof terminalValue === 'object' && 'then' in terminalValue
+                    ? terminalValue.then(value => ({ done: true, value }))
+                    : { done: true, value: terminalValue },
+            );
+        };
+    });
+    function delegate(innerIterator: TIterator, methodName: 'next' | 'throw') {
+        return (...args: Parameters<NonNullable<TIterator[typeof methodName]>>) => {
+            if (didTerminate) {
+                return getTerminalResponsePromise();
+            }
+            const terminalResponsePromise = getTerminalResponsePromise();
+            const innerResultPromise = innerIterator[methodName]!(...args);
+            return safeRace([
+                terminalResponsePromise,
+                innerResultPromise.catch(handleInnerRejection),
+                innerResultPromise.then(handleInnerResult),
+            ]);
+        };
+    }
+    function getTerminalResponsePromise() {
+        return terminalResponsePromise.then(shallowClone);
+    }
+    function handleInnerRejection<T>(e?: T): never {
+        terminateIterator();
+        throw e;
+    }
+    function handleInnerResult<T, TReturn>(result: IteratorResult<T, TReturn>) {
+        if (result.done) {
+            terminateIterator(result.value);
+        }
+        return result;
+    }
+    return Object.freeze({
+        /**
+         * We purposely do not spread non-iterator properties of the inner iterator here.
+         *
+         * Typically when an iterator offers additional properties the intent is to either inspect
+         * or affect the internal state of the iterator. An iterator that offers a `reset` method
+         * is one example.
+         *
+         * Our interruptible iterator is not designed to handle unpredictable state transitions of
+         * the inner iterator (eg. transitioning from `done: true` back to `done: false`). As such
+         * we want to strip out any extra properties that might allow the kind of access to the
+         * inner iterator that could cause such unpredictable state transitions.
+         */
+        next: delegate(innerIterator, 'next'),
+        return(value) {
+            if (!didTerminate) {
+                if (innerIterator.return) {
+                    /**
+                     * Though it's important to call the inner iterator's `return` method to force
+                     * it to run any cleanup code, we are not interested in its return value.
+                     * Waiting for the inner iterator's return value to resolve would invite the
+                     * possibility of a deadlock; the inner iterator's return value could, after
+                     * all, pend indefinitely.
+                     *
+                     * The design of our interruptible iterator demands that any pending iteration
+                     * of the inner iterator be abruptly interrupted by returning an
+                     * `IteratorReturnResult`, unconditionally and immediately.
+                     */
+                    innerIterator.return(value);
+                }
+                terminateIterator(value);
+            }
+            return getTerminalResponsePromise();
+        },
+        ...(innerIterator.throw ? { throw: delegate(innerIterator, 'throw') } : null),
+    } as MakeAsyncIteratorInterruptible<TIterator>);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -348,9 +348,16 @@ importers:
 
   packages/async:
     dependencies:
+      '@solana/promises':
+        specifier: workspace:*
+        version: link:../promises
       typescript:
         specifier: '>=5'
         version: 5.5.4
+    devDependencies:
+      '@solana/test-matchers':
+        specifier: workspace:*
+        version: link:../test-matchers
 
   packages/build-scripts:
     devDependencies:


### PR DESCRIPTION
# Summary

Some async iterators do work when you poll, and that work is expected to finish in a finite amount of time.

```ts
const stakeAccountKey = 0;
const stakeAccountAddresses = {
  async next() {
    const nextStakeAccountAddress = await deriveStakeAccountAddress(
      owner,
      `stake:${stakeAccountKey++}`
    );
    return { done: false, value: nextStakeAccountAddress };
  },
};
```

Async iterators that wrap push APIs like `EventEmitter` however can get into a situation where a consumer has polled (ie. called `next()`) before the emitter has produced the next value.

```ts
// Ignore all the obvious bugs.
let resolveNextNotification!;
const notifications = {
  async next() {
    const nextNotification = await new Promise((resolve) => {
      resolveNextNotification = resolve;
    });
    return { done: false, value: nextNotification };
  },
  return() {
    emitter.off("notificaton");
  },
};
emitter.on("notification", resolveNextNotification);
```

This implies that – unless the developer is extremely careful – an async iterator that wraps a _push_ API like this can easily find itself deadlocked indefinitely if the pusher never emits another event.

This PR introduces something called an interruptible iterator that races every call to an inner iterator's methods with a ‘termination promise’ that gets triggered immediately on calls to the outer iterator's `return` or `throw` methods.

See the README and the tests for more.
