### PR TITLE
Throw abort errors from the channel in cases where the abort is clear

### DIFF
--- a/packages/rpc-subscriptions-channel-websocket/src/__tests__/websocket-channel-test.ts
+++ b/packages/rpc-subscriptions-channel-websocket/src/__tests__/websocket-channel-test.ts
@@ -60,11 +60,7 @@ describe('createWebSocketChannel', () => {
             signal: abortController.signal,
             url: 'ws://fake', // Wrong URL!
         });
-        await expect(channelPromise).rejects.toThrow(
-            new SolanaError(SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED, {
-                cause: abortController.signal.reason,
-            }),
-        );
+        await expect(channelPromise).rejects.toThrow(/operation was aborted/);
     });
     it('throws when the channel is aborted before a connection is established', async () => {
         expect.assertions(2);
@@ -77,11 +73,7 @@ describe('createWebSocketChannel', () => {
         const client = getLatestClient();
         expect(client).toHaveProperty('readyState', WebSocket.CONNECTING);
         abortController.abort();
-        await expect(channelPromise).rejects.toThrow(
-            new SolanaError(SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_FAILED_TO_CONNECT, {
-                errorEvent: {} as Event,
-            }),
-        );
+        await expect(channelPromise).rejects.toThrow(/operation was aborted/);
     });
 });
 

--- a/packages/rpc-subscriptions-channel-websocket/src/websocket-channel.ts
+++ b/packages/rpc-subscriptions-channel-websocket/src/websocket-channel.ts
@@ -22,11 +22,7 @@ export function createWebSocketChannel({
     url,
 }: Config): Promise<RpcSubscriptionsChannel<WebSocketMessage, string>> {
     if (signal.aborted) {
-        return Promise.reject(
-            new SolanaError(SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_CONNECTION_CLOSED, {
-                cause: signal.reason,
-            }),
-        );
+        return Promise.reject(signal.reason);
     }
     let bufferDrainWatcher: Readonly<{ onCancel(): void; promise: Promise<void> }> | undefined;
     let hasConnected = false;
@@ -37,14 +33,10 @@ export function createWebSocketChannel({
         });
         listenerRemovers.clear();
     }
-    function handleAbort(ev: Event) {
+    function handleAbort() {
         cleanupListeners();
         if (!hasConnected) {
-            rejectOpen(
-                new SolanaError(SOLANA_ERROR__RPC_SUBSCRIPTIONS__CHANNEL_FAILED_TO_CONNECT, {
-                    errorEvent: ev,
-                }),
-            );
+            rejectOpen(signal.reason);
         }
         if (webSocket.readyState !== WebSocket.CLOSED && webSocket.readyState !== WebSocket.CLOSING) {
             webSocket.close(1000);

--- a/packages/rpc-subscriptions/README.md
+++ b/packages/rpc-subscriptions/README.md
@@ -48,3 +48,7 @@ Given an `RpcSubscriptionsChannel`, will return a new channel that parses data p
 ### `getRpcSubscriptionsChannelWithAutoping(channel)`
 
 Given an `RpcSubscriptionsChannel`, will return a new channel that sends a ping message to the inner channel if a message has not been sent or received in the last `intervalMs`. In web browsers, this implementation sends no ping when the network is down, and sends a ping immediately upon the network coming back up.
+
+### `getRpcSubscriptionsTransportWithSubscriptionCoalescing(transport)`
+
+Given an `RpcSubscriptionsTransport`, will return a new transport that coalesces identical subscriptions into a single subscription request to the server. The determination of whether a subscription is the same as another is based on the `subscriptionConfigurationHash` returned by its `RpcSubscriptionsPlan`. The subscription will only be aborted once all subscribers abort, or there is an error.

--- a/packages/rpc-subscriptions/package.json
+++ b/packages/rpc-subscriptions/package.json
@@ -78,7 +78,8 @@
         "@solana/rpc-subscriptions-channel-websocket": "workspace:*",
         "@solana/rpc-subscriptions-spec": "workspace:*",
         "@solana/rpc-transformers": "workspace:*",
-        "@solana/rpc-types": "workspace:*"
+        "@solana/rpc-types": "workspace:*",
+        "@solana/subscribable": "workspace:*"
     },
     "peerDependencies": {
         "typescript": ">=5"

--- a/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
+++ b/packages/rpc-subscriptions/src/__tests__/rpc-subscriptions-coalescer-test.ts
@@ -1,342 +1,239 @@
-import type { RpcSubscriptions } from '@solana/rpc-subscriptions-spec';
+import type { RpcSubscriptionsTransport } from '@solana/rpc-subscriptions-spec';
 
-import { getRpcSubscriptionsWithSubscriptionCoalescing } from '../rpc-subscriptions-coalescer';
+import { getRpcSubscriptionsTransportWithSubscriptionCoalescing } from '../rpc-subscriptions-coalescer';
 
-interface TestRpcSubscriptionNotifications {
-    nonFunctionProperty: string;
-    thingNotifications(...args: unknown[]): unknown;
-}
-
-describe('getRpcSubscriptionsWithSubscriptionCoalescing', () => {
-    let getAsyncIterable: jest.MockedFn<() => AsyncIterable<unknown>>;
-    let createPendingSubscription: jest.Mock;
-    let getDeduplicationKey: jest.Mock;
-    let subscribe: jest.Mock;
-    let rpcSubscriptions: RpcSubscriptions<TestRpcSubscriptionNotifications>;
+describe('getRpcSubscriptionsTransportWithSubscriptionCoalescing', () => {
+    let mockInnerTransport: jest.Mock;
+    let mockOn: jest.Mock;
+    let coalescedTransport: RpcSubscriptionsTransport;
+    function receiveError(err?: unknown) {
+        mockOn.mock.calls.filter(([type]) => type === 'error').forEach(([_, listener]) => listener(err));
+    }
     beforeEach(() => {
+        mockOn = jest.fn();
+        mockInnerTransport = jest.fn().mockResolvedValue({ on: mockOn });
+        coalescedTransport = getRpcSubscriptionsTransportWithSubscriptionCoalescing(mockInnerTransport);
+    });
+    it('returns the inner transport', async () => {
+        expect.assertions(1);
+        const expectedDataPublisher = { on: mockOn };
+        mockInnerTransport.mockResolvedValue(expectedDataPublisher);
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        const transportPromise = coalescedTransport(config);
+        await expect(transportPromise).resolves.toBe(expectedDataPublisher);
+    });
+    it('passes the `executeSubscriptionPlan` config to the inner transport', () => {
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        coalescedTransport(config);
+        expect(mockInnerTransport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                executeSubscriptionPlan: config.executeSubscriptionPlan,
+            }),
+        );
+    });
+    it('passes the `subscriptionConfigurationHash` config to the inner transport', () => {
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        coalescedTransport(config);
+        expect(mockInnerTransport).toHaveBeenCalledWith(
+            expect.objectContaining({
+                subscriptionConfigurationHash: 'MOCK_HASH',
+            }),
+        );
+    });
+    it('calls the inner transport once per subscriber whose hashes do not match, in the same runloop', () => {
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+        };
+        coalescedTransport({ ...config, subscriptionConfigurationHash: 'MOCK_HASH_A' });
+        coalescedTransport({ ...config, subscriptionConfigurationHash: 'MOCK_HASH_B' });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it('calls the inner transport once per subscriber whose hashes do not match, in different runloops', async () => {
+        expect.assertions(1);
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+        };
+        await coalescedTransport({ ...config, subscriptionConfigurationHash: 'MOCK_HASH_A' });
+        await coalescedTransport({ ...config, subscriptionConfigurationHash: 'MOCK_HASH_B' });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it("calls the inner transport once per subscriber when both subscribers' hashes are `undefined`, in the same runloop", () => {
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+        };
+        coalescedTransport({ ...config, subscriptionConfigurationHash: undefined });
+        coalescedTransport({ ...config, subscriptionConfigurationHash: undefined });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it("calls the inner transport once per subscriber when both subscribers' hashes are `undefined`, in different runloops", async () => {
+        expect.assertions(1);
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+        };
+        await coalescedTransport({ ...config, subscriptionConfigurationHash: undefined });
+        await coalescedTransport({ ...config, subscriptionConfigurationHash: undefined });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it('only calls the inner transport once, in the same runloop', () => {
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        coalescedTransport(config);
+        coalescedTransport(config);
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+    });
+    it('only calls the inner transport once, in different runloops', async () => {
+        expect.assertions(1);
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        await coalescedTransport(config);
+        await coalescedTransport(config);
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
+    });
+    it('delivers the same value to each subscriber, in the same runloop', async () => {
+        expect.assertions(1);
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        const [publisherA, publisherB] = await Promise.all([coalescedTransport(config), coalescedTransport(config)]);
+        expect(publisherA).toBe(publisherB);
+    });
+    it('delivers the same value to each subscriber, in different runloops', async () => {
+        expect.assertions(1);
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            signal: new AbortController().signal,
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        const publisherA = await coalescedTransport(config);
+        const publisherB = await coalescedTransport(config);
+        expect(publisherA).toBe(publisherB);
+    });
+    it('does not fire the inner abort signal if fewer than all subscribers abort, in the same runloop', () => {
         jest.useFakeTimers();
-        getAsyncIterable = jest.fn().mockImplementation(async function* () {
-            yield await new Promise(() => {
-                /* never resolve */
-            });
-        });
-        getDeduplicationKey = jest.fn();
-        subscribe = jest.fn().mockReturnValue({
-            [Symbol.asyncIterator]() {
-                return getAsyncIterable()[Symbol.asyncIterator]();
-            },
-        });
-        createPendingSubscription = jest.fn().mockReturnValue({ subscribe });
-        rpcSubscriptions = getRpcSubscriptionsWithSubscriptionCoalescing<TestRpcSubscriptionNotifications>({
-            getDeduplicationKey,
-            rpcSubscriptions: {
-                nonFunctionProperty: 'foo',
-                thingNotifications: createPendingSubscription,
-            },
-        });
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        const abortControllerB = new AbortController();
+        coalescedTransport({ ...config, signal: new AbortController().signal });
+        coalescedTransport({ ...config, signal: abortControllerB.signal });
+        abortControllerB.abort();
+        jest.runAllTicks();
+        expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', false);
     });
-    describe('given invocations that produce the same deduplication key', () => {
-        beforeEach(() => {
-            getDeduplicationKey.mockReturnValue('deduplication-key');
-        });
-        it("creates a pending subscription once, with the first invocation's config", async () => {
-            expect.assertions(2);
-            await Promise.all([
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'hello' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'world' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-            ]);
-            expect(createPendingSubscription).toHaveBeenCalledTimes(1);
-            expect(createPendingSubscription).toHaveBeenCalledWith({
-                payload: 'hello',
-            });
-        });
-        it('only calls subscribe once, in the same runloop', async () => {
-            expect.assertions(1);
-            await Promise.all([
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'hello' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'world' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-            ]);
-            expect(subscribe).toHaveBeenCalledTimes(1);
-        });
-        it('only calls subscribe once, in different runloops', async () => {
-            expect.assertions(1);
-            await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            expect(subscribe).toHaveBeenCalledTimes(1);
-        });
-        it('delivers different iterables to each subscription, in the same runloop', async () => {
-            expect.assertions(1);
-            const [iterableA, iterableB] = await Promise.all([
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'hello' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'world' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-            ]);
-            expect(iterableA).not.toBe(iterableB);
-        });
-        it('delivers different iterables to each subscription, in different runloops', async () => {
-            expect.assertions(1);
-            const iterableA = await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            const iterableB = await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            expect(iterableA).not.toBe(iterableB);
-        });
-        it('publishes the same messages through both iterables', async () => {
-            expect.assertions(2);
-            getAsyncIterable.mockImplementation(async function* () {
-                yield Promise.resolve('hello');
-            });
-            const iterableA = await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            const iterableB = await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            const iteratorA = iterableA[Symbol.asyncIterator]();
-            const iteratorB = iterableB[Symbol.asyncIterator]();
-            const messagePromiseA = iteratorA.next();
-            const messagePromiseB = iteratorB.next();
-            await jest.runAllTimersAsync();
-            await expect(messagePromiseA).resolves.toHaveProperty('value', 'hello');
-            await expect(messagePromiseB).resolves.toHaveProperty('value', 'hello');
-        });
-        it('publishes the final message when the iterable returns', async () => {
-            expect.assertions(1);
-            getAsyncIterable.mockImplementation(
-                // eslint-disable-next-line require-yield
-                async function* () {
-                    return await Promise.resolve('hello');
-                },
-            );
-            const iterable = await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            const iterator = iterable[Symbol.asyncIterator]();
-            const messagePromise = iterator.next();
-            await expect(messagePromise).resolves.toHaveProperty('value', 'hello');
-        });
-        it('aborting a subscription causes it to return', async () => {
-            expect.assertions(1);
-            getAsyncIterable.mockImplementation(async function* () {
-                yield Promise.resolve('hello');
-            });
-            const abortController = new AbortController();
-            const iterable = await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: abortController.signal });
-            const iterator = iterable[Symbol.asyncIterator]();
-            const messagePromise = iterator.next();
-            abortController.abort();
-            await expect(messagePromise).resolves.toHaveProperty('done', true);
-        });
-        it('aborting one subscription does not abort the other', async () => {
-            expect.assertions(1);
-            getAsyncIterable.mockImplementation(async function* () {
-                yield Promise.resolve('hello');
-            });
-            const abortControllerA = new AbortController();
-            await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: abortControllerA.signal });
-            const iterableB = await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            const iteratorB = iterableB[Symbol.asyncIterator]();
-            const messagePromiseB = iteratorB.next();
-            abortControllerA.abort();
-            await jest.runAllTimersAsync();
-            await expect(messagePromiseB).resolves.toHaveProperty('value', 'hello');
-        });
+    it('fires the inner abort signal if all subscribers abort, in the same runloop', () => {
+        jest.useFakeTimers();
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        const abortControllerA = new AbortController();
+        const abortControllerB = new AbortController();
+        coalescedTransport({ ...config, signal: abortControllerA.signal });
+        coalescedTransport({ ...config, signal: abortControllerB.signal });
+        abortControllerA.abort();
+        abortControllerB.abort();
+        jest.runAllTicks();
+        expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', true);
     });
-    describe('given payloads that produce different deduplication keys', () => {
-        beforeEach(() => {
-            let deduplicationKey = 0;
-            getDeduplicationKey.mockImplementation(() => `${++deduplicationKey}`);
-        });
-        it('creates a pending subscription for each', async () => {
-            expect.assertions(3);
-            await Promise.all([
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'hello' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'world' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-            ]);
-            expect(createPendingSubscription).toHaveBeenCalledTimes(2);
-            expect(createPendingSubscription).toHaveBeenNthCalledWith(1, {
-                payload: 'hello',
-            });
-            expect(createPendingSubscription).toHaveBeenNthCalledWith(2, {
-                payload: 'world',
-            });
-        });
-        it('calls subscribe once for each subscription, in the same runloop', async () => {
-            expect.assertions(1);
-            await Promise.all([
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'hello' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'world' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-            ]);
-            expect(subscribe).toHaveBeenCalledTimes(2);
-        });
-        it('calls subscribe once for each subscription, in different runloops', async () => {
-            expect.assertions(1);
-            await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            expect(subscribe).toHaveBeenCalledTimes(2);
-        });
-        it('delivers different iterables to each subscription, in the same runloop', async () => {
-            expect.assertions(1);
-            const [iterableA, iterableB] = await Promise.all([
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'hello' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'world' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-            ]);
-            expect(iterableA).not.toBe(iterableB);
-        });
-        it('delivers different iterables to each subscription, in different runloops', async () => {
-            expect.assertions(1);
-            const iterableA = await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            const iterableB = await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            expect(iterableA).not.toBe(iterableB);
-        });
-        it('publishes messages through the correct iterable', async () => {
-            expect.assertions(2);
-            subscribe.mockResolvedValueOnce({
-                async *[Symbol.asyncIterator]() {
-                    yield Promise.resolve('hello');
-                },
-            });
-            const iterableA = await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            subscribe.mockResolvedValueOnce({
-                async *[Symbol.asyncIterator]() {
-                    yield Promise.resolve('world');
-                },
-            });
-            const iterableB = await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            const iteratorA = iterableA[Symbol.asyncIterator]();
-            const iteratorB = iterableB[Symbol.asyncIterator]();
-            const messagePromiseA = iteratorA.next();
-            const messagePromiseB = iteratorB.next();
-            await jest.runAllTimersAsync();
-            await expect(messagePromiseA).resolves.toHaveProperty('value', 'hello');
-            await expect(messagePromiseB).resolves.toHaveProperty('value', 'world');
-        });
-        it('aborting a subscription causes it to return', async () => {
-            expect.assertions(1);
-            getAsyncIterable.mockImplementation(async function* () {
-                yield Promise.resolve('hello');
-            });
-            const abortController = new AbortController();
-            const iterable = await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: abortController.signal });
-            const iterator = iterable[Symbol.asyncIterator]();
-            const messagePromise = iterator.next();
-            abortController.abort();
-            await expect(messagePromise).resolves.toHaveProperty('done', true);
-        });
-        it('aborting one subscription does not abort the other', async () => {
-            expect.assertions(1);
-            getAsyncIterable.mockImplementation(async function* () {
-                yield Promise.resolve('hello');
-            });
-            const abortControllerA = new AbortController();
-            await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: abortControllerA.signal });
-            const iterableB = await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            const iteratorB = iterableB[Symbol.asyncIterator]();
-            const messagePromiseB = iteratorB.next();
-            abortControllerA.abort();
-            await jest.runAllTimersAsync();
-            await expect(messagePromiseB).resolves.toHaveProperty('value', 'hello');
-        });
+    it('fires the inner abort signal if all subscribers abort, in different runloops', async () => {
+        expect.assertions(1);
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        const abortControllerA = new AbortController();
+        const abortControllerB = new AbortController();
+        coalescedTransport({ ...config, signal: abortControllerA.signal });
+        await jest.runAllTimersAsync();
+        coalescedTransport({ ...config, signal: abortControllerB.signal });
+        await jest.runAllTimersAsync();
+        abortControllerA.abort();
+        abortControllerB.abort();
+        jest.runAllTicks();
+        expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', true);
     });
-    describe('given payloads that produce no deduplcation key', () => {
-        beforeEach(() => {
-            getDeduplicationKey.mockReturnValue(undefined);
-        });
-        it('creates a pending subscription for each', async () => {
-            expect.assertions(3);
-            await Promise.all([
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'hello' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'world' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-            ]);
-            expect(createPendingSubscription).toHaveBeenCalledTimes(2);
-            expect(createPendingSubscription).toHaveBeenNthCalledWith(1, {
-                payload: 'hello',
-            });
-            expect(createPendingSubscription).toHaveBeenNthCalledWith(2, {
-                payload: 'world',
-            });
-        });
-        it('calls subscribe once for each subscription, in the same runloop', async () => {
-            expect.assertions(1);
-            await Promise.all([
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'hello' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-                rpcSubscriptions
-                    .thingNotifications({ payload: 'world' })
-                    .subscribe({ abortSignal: new AbortController().signal }),
-            ]);
-            expect(subscribe).toHaveBeenCalledTimes(2);
-        });
-        it('calls subscribe once for each subscription, in different runloops', async () => {
-            expect.assertions(1);
-            await rpcSubscriptions
-                .thingNotifications({ payload: 'hello' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            await rpcSubscriptions
-                .thingNotifications({ payload: 'world' })
-                .subscribe({ abortSignal: new AbortController().signal });
-            expect(subscribe).toHaveBeenCalledTimes(2);
-        });
+    it('does not fire the inner abort signal if the subscriber count is non zero at the end of the runloop, despite having aborted all in the middle of it', () => {
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        const abortControllerA = new AbortController();
+        coalescedTransport({ ...config, signal: abortControllerA.signal });
+        abortControllerA.abort();
+        coalescedTransport({ ...config, signal: new AbortController().signal });
+        jest.runAllTicks();
+        expect(mockInnerTransport.mock.lastCall?.[0].signal).toHaveProperty('aborted', false);
     });
-    it('does not shim non-function properties on the RPC', () => {
-        expect(rpcSubscriptions.nonFunctionProperty).toBe('foo');
+    it('does not re-coalesce new requests behind an errored transport', async () => {
+        expect.assertions(1);
+        jest.useFakeTimers();
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        coalescedTransport({ ...config, signal: new AbortController().signal });
+        await jest.runAllTimersAsync();
+        receiveError('o no');
+        coalescedTransport({ ...config, signal: new AbortController().signal });
+        expect(mockInnerTransport).toHaveBeenCalledTimes(2);
+    });
+    it('does not cancel a newly-coalesced transport when an old errored one is aborted', async () => {
+        expect.assertions(2);
+        jest.useFakeTimers();
+        const config = {
+            executeSubscriptionPlan: jest.fn(),
+            subscriptionConfigurationHash: 'MOCK_HASH',
+        };
+        const abortControllerA = new AbortController();
+        /**
+         * PHASE 1
+         * Create and fail a transport.
+         */
+        await coalescedTransport({ ...config, signal: abortControllerA.signal });
+        receiveError('o no');
+        mockInnerTransport.mockClear();
+        /**
+         * PHASE 2
+         * Create a new transport
+         */
+        const publisherA = await coalescedTransport({ ...config, signal: new AbortController().signal });
+        /**
+         * PHASE 3
+         * Abort the original subscriber
+         */
+        abortControllerA.abort();
+        jest.runAllTicks();
+        /**
+         * PHASE 4
+         * Create a new transport and expect it to coalesce behind the one in phase 2
+         */
+        const publisherB = await coalescedTransport({ ...config, signal: new AbortController().signal });
+        expect(publisherA).toBe(publisherB);
+        expect(mockInnerTransport).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/rpc-subscriptions/src/rpc-subscriptions-transport.ts
+++ b/packages/rpc-subscriptions/src/rpc-subscriptions-transport.ts
@@ -12,6 +12,7 @@ import {
     RpcSubscriptionsTransportMainnet,
     RpcSubscriptionsTransportTestnet,
 } from './rpc-subscriptions-clusters';
+import { getRpcSubscriptionsTransportWithSubscriptionCoalescing } from './rpc-subscriptions-coalescer';
 
 export type DefaultRpcSubscriptionsTransportConfig<TClusterUrl extends ClusterUrl> = Readonly<{
     createChannel: RpcSubscriptionsChannelCreatorFromClusterUrl<TClusterUrl, unknown, unknown>;
@@ -24,6 +25,7 @@ export function createDefaultRpcSubscriptionsTransport<TClusterUrl extends Clust
         createRpcSubscriptionsTransportFromChannelCreator(
             createChannel,
         ) as RpcSubscriptionsTransport as RpcSubscriptionsTransportFromClusterUrl<TClusterUrl>,
+        transport => getRpcSubscriptionsTransportWithSubscriptionCoalescing(transport),
     );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,6 +880,9 @@ importers:
       '@solana/rpc-types':
         specifier: workspace:*
         version: link:../rpc-types
+      '@solana/subscribable':
+        specifier: workspace:*
+        version: link:../subscribable
       typescript:
         specifier: '>=5'
         version: 5.5.2


### PR DESCRIPTION
# Summary

We need to take a harder line on what happens when an abort signal is fired. When something is aborted, it's aborted. An `AbortError` must be thrown. Not a ‘connection failed to be made’ error. That is disingenous, when the real reason the app is throwing is because the developer aborted the connection.
