### PR TITLE
Run examples in CI checks

### DIFF
--- a/examples/rpc-transport-throttled/src/example.ts
+++ b/examples/rpc-transport-throttled/src/example.ts
@@ -107,9 +107,8 @@ function getThrottledTransport<TClusterUrl extends ClusterUrl>(
  * Create a default RPC transport, wrap it in a throttled transport, then create a Solana RPC
  * instance from the resulting transport.
  */
-const defaultTransport = createDefaultRpcTransport({
-    url: mainnet('https://api.mainnet-beta.solana.com'),
-});
+const url = process.env.CI ? 'http://127.0.0.1:8899' : mainnet('https://api.mainnet-beta.solana.com');
+const defaultTransport = createDefaultRpcTransport({ url });
 const throttledTransport = getThrottledTransport(defaultTransport);
 const throttledRpc = createSolanaRpcFromTransport(throttledTransport);
 

--- a/examples/utils/pressAnyKeyPrompt.ts
+++ b/examples/utils/pressAnyKeyPrompt.ts
@@ -3,8 +3,12 @@ import colors from 'yoctocolors';
 
 export default createPrompt<void, string>((message = 'Press any key to exit', done) => {
     const prefix = usePrefix({});
-    useKeypress(() => {
+    if (process.env.CI) {
         done();
-    });
+    } else {
+        useKeypress(() => {
+            done();
+        });
+    }
     return `${prefix} ${colors.bold(message)}`;
 });

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
     "$schema": "https://turbo.build/schema.json",
+    "globalEnv": ["CI"],
     "remoteCache": {
         "signature": true
     },
@@ -15,7 +16,8 @@
                 "test:treeshakability:node",
                 "test:typecheck",
                 "test:unit:browser",
-                "test:unit:node"
+                "test:unit:node",
+                "start"
             ],
             "outputs": ["dist/**"]
         },
@@ -44,6 +46,10 @@
                 "test:treeshakability:node"
             ],
             "passThroughEnv": ["GH_TOKEN", "NPM_TOKEN"]
+        },
+        "start": {
+            "dependsOn": ["^compile:js", "^compile:typedefs"],
+            "inputs": ["$TURBO_DEFAULT$", "src/**", "../utils/**"]
         },
         "style:fix": {
             "inputs": ["$TURBO_DEFAULT$", "*"],


### PR DESCRIPTION
This PR adds the `start` script in the `build` pipeline such that CI ends up not just linting and type-checking examples but also making sure they run without failing.

To do so, I've had to tweak the `pressAnyKeyToContinue` helper since otherwise CI just force-closes the session after a timeout. For that, we can use the `process.env.CI` variable provided in GitHub Actions environments.

Also note that CI purposefully fails here (for the correct reason) since we currently have a failing example (due to one of my previous refactoring). The following PR fixes the example to show that fixes the example also makes CI pass.

**EDIT**: Additionally, I've had to change the RPC URL in CI, otherwise we will keep getting 429 when trying to hit mainnet.