### PR TITLE
feat: agave v2 rpc: replace `getStakeActivation` with rpc-client-extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "test:unit": "cross-env NODE_ENV=test NODE_OPTIONS='--import tsx' mocha './test/**/*.test.ts'"
   },
   "dependencies": {
+    "@anza-xyz": "github:buffalojoec/solana-rpc-client-extensions#do-not-actually-use-web3-js",
     "@babel/runtime": "^7.25.0",
     "@noble/curves": "^1.4.2",
     "@noble/hashes": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@anza-xyz':
+        specifier: github:buffalojoec/solana-rpc-client-extensions#do-not-actually-use-web3-js
+        version: solana-rpc-client-extensions#do-not-actually-use-web3-js@https://codeload.github.com/buffalojoec/solana-rpc-client-extensions/tar.gz/a2d5f9446ad1fbb8478303b74fc5e3eb36f682ea
       '@babel/runtime':
         specifier: ^7.25.0
         version: 7.26.0
@@ -2366,7 +2369,6 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esm@3.2.25:
@@ -4051,6 +4053,10 @@ packages:
   socks@2.8.1:
     resolution: {integrity: sha512-B6w7tkwNid7ToxjZ08rQMT8M9BJAf8DKx8Ft4NivzH0zBUfd6jldGcisJn/RLgxcX3FPNDdNQCUEMMT79b+oCQ==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  solana-rpc-client-extensions#do-not-actually-use-web3-js@https://codeload.github.com/buffalojoec/solana-rpc-client-extensions/tar.gz/a2d5f9446ad1fbb8478303b74fc5e3eb36f682ea:
+    resolution: {tarball: https://codeload.github.com/buffalojoec/solana-rpc-client-extensions/tar.gz/a2d5f9446ad1fbb8478303b74fc5e3eb36f682ea}
+    version: 0.0.0
 
   source-map-support@0.5.21:
     resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
@@ -8824,6 +8830,8 @@ snapshots:
     dependencies:
       ip-address: 9.0.5
       smart-buffer: 4.2.0
+
+  solana-rpc-client-extensions#do-not-actually-use-web3-js@https://codeload.github.com/buffalojoec/solana-rpc-client-extensions/tar.gz/a2d5f9446ad1fbb8478303b74fc5e3eb36f682ea: {}
 
   source-map-support@0.5.21:
     dependencies:


### PR DESCRIPTION
Draft implementation of replacing `getStakeActivation` with the extension API over at https://github.com/anza-xyz/solana-rpc-client-extensions.

This is just to show what it would look like if we consumed the API directly. We also may have to reimplement the code, considering the dependency on web3.js.