### PR TITLE
refactor(Keypair): add Kit Signer Support

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -21,6 +21,7 @@ These notes summarize the user-facing changes that landed since 1.98.4.
 - `Address.unique()` was removed.
 - Legacy BN-era `PublicKey` constructor inputs such as `PublicKeyData` or `{ _bn: BN }` are no longer accepted.
 - `Keypair.generate()`, `Keypair.fromSecretKey(...)`, and `Keypair.fromSeed(...)` are now async. Tests and stories that previously used sync key generation often need to become async or switch to app-local dummy public-key helpers.
+- `Keypair.address` is now a Kit branded base58 address string for signer API compatibility. Use `Keypair.publicKey` when you need the web3.js `Address` class methods such as `.toBytes()`, `.equals(...)`, or `.toBase58()`.
 - `Transaction.verifySignatures()` is now async and returns a promise.
 - `Transaction.serialize()` is now async and must be awaited.
 - Remaining sync signing helpers that existed earlier in the range were removed in favor of the async signing surface.
@@ -49,7 +50,10 @@ These notes summarize the user-facing changes that landed since 1.98.4.
 ### Addresses, transactions, and signing
 
 - `Address` replaces `PublicKey` as the primary type, while preserving backward compatibility through the alias export.
-- `Keypair.address` is now the preferred property for a keypair's public address, while `Keypair.publicKey` remains as a deprecated compatibility alias.
+- `Keypair` now implements the `@solana/signers` `KeyPairSigner` shape. It exposes `address`, `keyPair`, `signMessages(...)`, and `signTransactions(...)`, and can be passed directly to Kit APIs that accept a `KeyPairSigner`.
+- `Keypair.address` is the Kit branded base58 signer address. `Keypair.publicKey` remains the web3.js `Address` object for class-based address operations.
+- The exported `Signer` type is now a union of the legacy web3.js shape (`Web3Signer`, `publicKey` + `secretKey`) and Kit's `MessagePartialSigner` and `TransactionPartialSigner`. The v1 shape is preserved under the new name `Web3Signer`, and the new `Signer` union remains compatible with the v1 usage pattern of passing `{publicKey, secretKey}` objects into `Transaction.sign(...)` and related APIs. Custom signers that previously exposed an ad-hoc `signBytes(...)` function should implement Kit's `MessagePartialSigner` shape instead.
+- `Transaction.sign(...)`, `Transaction.partialSign(...)`, `VersionedTransaction.sign(...)`, `Connection.sendTransaction(...)`, `Connection.simulateTransaction(...)`, and `sendAndConfirmTransaction(...)` can now sign with compatible Kit signer objects.
 - Verification is now WebCrypto/Kit-backed and async-only.
 - Transaction and message internals were normalized around `Uint8Array`, including instruction data, signatures, serialization, and deserialization.
 - Buffer-backed public APIs now accept `Uint8Array`, sliced views, and `Array<number>` more consistently.
@@ -76,5 +80,7 @@ These notes summarize the user-facing changes that landed since 1.98.4.
 - If you serialize SDK responses or mocks with `JSON.stringify`, remember that raw `bigint` values throw without a replacer.
 - Prefer propagating `bigint` through app state and only converting with `Number(...)` at display or interoperability boundaries, with safe-range checks where precision matters.
 - Replace direct `PublicKey`-specific constructor assumptions with `Address`-compatible usage.
+- Replace `keypair.address.toBytes()`, `keypair.address.equals(...)`, and `keypair.address.toBase58()` with `keypair.publicKey.toBytes()`, `keypair.publicKey.equals(...)`, and `keypair.publicKey.toBase58()`. If you only need the base58 signer address, use `keypair.address` directly.
+- Prefer passing Kit-compatible signers directly to transaction signing APIs instead of wrapping them in noop signers solely to satisfy web3.js types.
 - Replace any dependency on removed helper APIs such as `Address.unique()`, FeeCalculator-related methods, or BN-era key construction.
 - If you depend on Buffer-based decoders, convert at that boundary with `Buffer.from(...)` or a zero-copy aliasing form for hot paths instead of keeping `Buffer` as your internal default.

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@solana/fast-stable-stringify": "^6.8.0",
     "@solana/kit": "^6.8.0",
     "@solana/rpc-spec-types": "^6.8.0",
+    "@solana/signers": "^6.8.0",
     "@solana-program/address-lookup-table": "^0.11.0",
     "@solana-program/compute-budget": "^0.15.0",
     "@solana-program/stake": "^0.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@solana/rpc-spec-types':
         specifier: ^6.8.0
         version: 6.8.0(typescript@5.9.3)
+      '@solana/signers':
+        specifier: ^6.8.0
+        version: 6.8.0(typescript@5.9.3)
     devDependencies:
       '@commitlint/config-conventional':
         specifier: ^19.2.2

--- a/skills/web3js-v1-to-v3-migration/SKILL.md
+++ b/skills/web3js-v1-to-v3-migration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: web3js-v1-to-v3-migration
-description: 'Migrate legacy @solana/web3.js v1 applications to v3. Use when auditing or fixing code after upgrading for Address/PublicKey changes, removed unique/Account/FeeCalculator APIs, async Keypair and transaction flows, Connection commitment and bigint changes, Buffer-to-Uint8Array migration, readonly RPC results, and SDK-specific type changes.'
+description: 'Migrate legacy @solana/web3.js v1 applications to v3. Use when auditing or fixing code after upgrading for Address/PublicKey changes, Keypair.address vs publicKey changes, Kit signer API interop, removed unique/Account/FeeCalculator APIs, async Keypair and transaction flows, Connection commitment and bigint changes, Buffer-to-Uint8Array migration, readonly RPC results, and SDK-specific type changes.'
 user-invocable: true
 ---
 
@@ -9,20 +9,24 @@ user-invocable: true
 For human-facing background, see [`docs/web3js-v1-to-v3-migration.md`](../../docs/web3js-v1-to-v3-migration.md). This skill is the execution-oriented companion for agents fixing code.
 
 ## When to Use
+
 - Migrating an application, SDK, script, or test suite from legacy `@solana/web3.js` v1 assumptions to the v3 API and runtime model.
 - Auditing a codebase after a dependency bump when failures likely come from removed helpers, async key or transaction APIs, stricter key handling, `bigint` RPC values, readonly wrappers, or byte-array changes.
-- Updating older examples or guides that still use `PublicKey`-specific internals, removed `unique()` helpers, removed `Connection` methods, `Buffer`-centric code, or older program helpers.
+- Updating older examples or guides that still use `PublicKey`-specific internals, assume `keypair.address` is a web3.js `Address` object, wrap Kit signers unnecessarily, use removed `unique()` helpers, removed `Connection` methods, `Buffer`-centric code, or older program helpers.
 - Reviewing a migration PR to find compatibility gaps, silent behavior changes, and missing regression tests.
 
 ## Goal
+
 Provide an agent workflow that finds the highest-risk breakage first, makes concrete code updates, and validates each migrated slice before moving on.
 
 ## Operating Model
+
 - Work in narrow, behavior-scoped slices. Start at a shared boundary, fix one class of breakage, validate it, then widen.
 - Treat most churn as mechanical rather than architectural: `bigint` numerics, `Uint8Array` account data, async key and transaction helpers, readonly RPC results, and stricter SDK value types are the main recurring sources of breakage.
 - Prefer SDK-derived types and current public APIs over app-local compatibility shims unless the shim clearly owns a boundary.
 
 ## Fast Triage
+
 Use regex-capable search for these patterns before chasing softer type churn:
 
 - `PublicKey.unique`
@@ -30,6 +34,8 @@ Use regex-capable search for these patterns before chasing softer type churn:
 - `FeeCalculator|getRecentBlockhash|getRecentBlockhashAndContext|getFeeCalculatorForBlockhash`
 - `sign|partialSign|VersionedTransaction.sign`
 - `Keypair.generate\(\)\.publicKey|Keypair.generate\(|fromSecretKey\(|fromSeed\(|createProgramAddressSync|findProgramAddressSync`
+- `keypair\.address\.|\.address\.toBytes|\.address\.equals|\.address\.toBase58`
+- `createNoopSigner|createSignerFromKeyPair|KeyPairSigner|MessagePartialSigner|TransactionPartialSigner|signMessages|signTransactions`
 - app-local wrappers around message signing or signature verification
 - `serialize()` on legacy `Transaction` call sites that assume sync behavior
 - `PublicKeyData|_bn|new PublicKey(`
@@ -41,9 +47,11 @@ Use regex-capable search for these patterns before chasing softer type churn:
 ## Recommended Agent Workflow
 
 ### 1. Start at the dependency boundary
+
 Search for `@solana/web3.js` imports, wrapper modules, and app-local compatibility layers that re-export Solana types. Migrate the narrowest shared boundary first so downstream fixes become smaller.
 
 ### 2. Audit hard breaks first
+
 Search for removed APIs and signatures before chasing softer type churn:
 
 - `PublicKey.unique`
@@ -54,18 +62,26 @@ Search for removed APIs and signatures before chasing softer type churn:
 - `getFeeCalculatorForBlockhash`
 
 ### 3. Migrate key and address handling
+
 Check whether the app only uses public keys as opaque values, or whether it depends on old `PublicKey` constructor internals, identity checks, BN.js inputs, or custom wrappers around those behaviors.
 
-- When touched code reads a keypair's public identity, prefer `keypair.address`; `keypair.publicKey` still works as a deprecated compatibility alias.
+- `keypair.address` is now the Kit branded base58 signer address string. Use it when code only needs the address string or when passing a keypair into Kit/Codama signer-aware APIs.
+- `keypair.publicKey` remains the web3.js `Address` object. Use it when code needs `.toBytes()`, `.equals(...)`, `.toBase58()`, `.verifySignature(...)`, or APIs that still take class-based `Address` values.
+- Replace `keypair.address.toBytes()`, `keypair.address.equals(x)`, and `keypair.address.toBase58()` with `keypair.publicKey.toBytes()`, `keypair.publicKey.equals(x)`, and `keypair.publicKey.toBase58()` respectively.
 - If code only stores, passes, compares, or prints key values, migrate touched code toward `Address` semantics and strict input validation.
 - `Address.toBase58()` now returns the branded `KitAddress` string type rather than a plain `string`, so keep that type through SDK-aware code and only narrow it at generic string boundaries.
 - If code depends on constructor internals, BN.js coercions, or class identity details, rewrite those call sites directly rather than assuming the alias preserves legacy behavior.
 - Replace removed `PublicKey.unique()` usage with a local dummy-address generator in tests and fixtures.
 
 ### 4. Migrate async crypto and transaction flows
+
 Find call sites that previously assumed sync behavior for signature verification, key generation, message signing, transaction signing, PDA derivation, or legacy transaction serialization.
 
 - Add `await` to current async methods: `transaction.sign(...)`, `transaction.partialSign(...)`, and `versionedTransaction.sign(...)`.
+- Prefer Kit-compatible signer APIs when integrating with Kit, Kit Plugins, Codama-generated clients, browser wallets, ledgers, or custom signing systems. `Keypair` now provides `signMessages(...)`, `signTransactions(...)`, and `keyPair`, and structurally satisfies Kit's `KeyPairSigner` shape so it can be passed directly to Kit APIs that accept one.
+- Pass compatible Kit `MessagePartialSigner` or `TransactionPartialSigner` values directly to web3.js transaction signing APIs instead of adapting them through noop signers only to satisfy legacy types.
+- Do not assume every Kit `TransactionSigner` can sign a web3.js transaction. The exported `Signer` type is now a union of the v1 `Web3Signer` shape (`publicKey` + `secretKey`) and Kit `MessagePartialSigner` / `TransactionPartialSigner` values; sending-only or modifying-only signers need a boundary that understands those behaviors. Custom signers that only expose an ad-hoc `signBytes(...)` function should implement Kit's `MessagePartialSigner` shape rather than relying on a bespoke web3.js byte-signer interface.
+- The v1 `Signer` interface has been renamed to `Web3Signer`. v1 code that passes arrays of `{publicKey, secretKey}` objects continues to work because the new `Signer` union includes that shape. v1 code that holds a `Signer`-typed value and reads `.secretKey` directly should either narrow with `if ('secretKey' in signer)` or switch the type annotation to `Web3Signer`.
 - Replace sync PDA helpers with the current async surfaces:
   - `PublicKey.createProgramAddressSync(...)` -> `await Address.createProgramAddress(...)`
   - `PublicKey.findProgramAddressSync(...)` -> `await Address.findProgramAddress(...)`
@@ -73,11 +89,13 @@ Find call sites that previously assumed sync behavior for signature verification
   - sign raw bytes with `await keypair.signBytes(messageBytes)`
   - verify signatures with `await keypair.verifySignature(signature, messageBytes)` or `await address.verifySignature(signature, messageBytes)`
 - Add `async` to any function that now calls `Keypair.generate()`, `Keypair.fromSecretKey(...)`, `Keypair.fromSeed(...)`, `Address.createProgramAddress(...)`, `Address.findProgramAddress(...)`, transaction signing, signature verification, or legacy `Transaction.serialize(...)`, then add the corresponding `await` at each call site.
-- Fix immediate sync assumptions after those calls: if code reads `.address` or deprecated `.publicKey` from a newly created keypair, inspects transaction signatures right after signing, serializes a legacy transaction, or sends it immediately after signing, move that logic after the awaited call.
+- Fix immediate sync assumptions after those calls: if code reads `.address` or `.publicKey` from a newly created keypair, inspects transaction signatures right after signing, serializes a legacy transaction, or sends it immediately after signing, move that logic after the awaited call.
+- If code converts a web3.js keypair for Kit APIs, prefer passing the keypair directly where a `KeyPairSigner` is accepted — `Keypair` structurally satisfies `KeyPairSigner` and `isKeyPairSigner(keypair)` returns `true`. Use `createSignerFromKeyPair(keypair.keyPair)` only when an API specifically needs a freshly constructed signer from a raw `CryptoKeyPair`.
 - Do not hide async migration work behind mixed sync wrappers unless the wrapper owns real scheduling or lifecycle behavior.
 - Pay special attention to tests and stories that used `Keypair.generate().publicKey` or removed `unique()` helpers such as `Address.unique()` or `PublicKey.unique()` as shorthand for a unique address; replace them with a dummy-address helper instead of spreading async churn through the test.
 
 ### 5. Audit `Connection` behavior and numeric types
+
 Identify code that relied on the old implicit `finalized` default or on numeric RPC results being JavaScript `number` values.
 
 - If the app needs `finalized`, set it explicitly.
@@ -85,6 +103,7 @@ Identify code that relied on the old implicit `finalized` default or on numeric 
 - If those values appear in fixtures or mocked RPC payloads, update the fixtures too instead of coercing production code back to `number`.
 
 ### 6. Migrate bytes and binary data
+
 Search for `Buffer` assumptions in transaction instruction data, signatures, message serialization, hashing, and account decoding.
 
 - Prefer `Uint8Array` and array-like byte inputs.
@@ -92,101 +111,136 @@ Search for `Buffer` assumptions in transaction instruction data, signatures, mes
 - If a decoder or third-party dependency still requires `Buffer`, convert at that edge instead of carrying `Buffer` through the app.
 
 ### 7. Audit readonly wrappers and SDK value types
+
 Search for in-place mutations (`sort`, `push`, direct assignment) on RPC results and for local helper types that mirror SDK shapes with plain `string`, `number`, or mutable arrays.
 
 - Copy collections before mutating.
 - Prefer SDK-derived types when readonly wrappers or more specific SDK value types are now part of the contract.
 
 ### 8. Update program and codec surfaces
+
 Inspect uses of system, stake, vote, compute-budget, address-lookup-table, and account-decoder utilities.
 
 - Replace deprecated layout or manual decode assumptions with the current codec-backed or generated-client-backed public APIs.
 - If the app decodes raw account data manually, verify field widths and enum variants instead of carrying old layout constants forward.
 
 ### 9. Revalidate by slice
+
 After each migration slice, run the narrowest test or smoke check that exercises that surface, then widen to typecheck and broader integration coverage.
 
 ## Concrete Code Fixes
 
 ### Removed helpers and legacy APIs
+
 - Replace removed `unique()` helper usage with a local dummy-address helper in tests or fixtures.
 - Replace removed fee-calculator and recent-blockhash-era APIs with current blockhash and fee surfaces at the boundary that owns transaction assembly.
 - Remove app-local compatibility shims that only preserve old constructor internals or deprecated layout assumptions.
 
 ### Async boundary edits
+
 - Apply the async transaction-signing and raw-crypto replacements listed above under "Migrate async crypto and transaction flows," then repair the surrounding control flow.
 - If a function now awaits key generation, PDA derivation, signing, signature verification, or legacy transaction serialization, mark that function `async` and propagate the promise outward coherently.
 - When reviewing a migration diff, check for follow-on bugs where code reads signatures, serializes a legacy transaction, or sends it before the awaited signing call completes.
 
 ### Type and data edits
+
 - Widen slot, block height, lamports-like, epoch, and context fields to accept `bigint`.
 - Convert `Buffer`-typed account data or instruction data to `Uint8Array`, and only re-wrap at third-party boundaries that still require `Buffer`.
 - Clone readonly RPC arrays before calling mutating helpers like `.sort()` or `.push()`.
 - Prefer SDK-derived types over hand-maintained primitive mirrors for `Address`, `Blockhash`, `Slot`, `Lamports`, and timestamp-like values.
+- Use `KeyPairSigner`, `MessagePartialSigner`, and `TransactionPartialSigner` from `@solana/web3.js` or `@solana/signers` instead of app-local signer interfaces when crossing Kit-aware boundaries.
 
 ## Decision Rules
 
 ### `PublicKey` vs `Address`
+
 - If code only stores, passes, compares, or prints key values, the `PublicKey` alias may be enough short term, but touched code should move toward `Address` semantics.
 - If code depends on constructor internals, BN.js coercions, or class identity details, rewrite those call sites directly.
+- If code uses a keypair's identity, choose by shape: `keypair.address` for Kit base58 signer address strings, `keypair.publicKey` for the web3.js `Address` class.
+
+### Signer interop
+
+- If the signer is a web3.js `Keypair`, pass it directly to Kit APIs that accept `KeyPairSigner` or to web3.js transaction signing APIs.
+- If the signer is a Kit `MessagePartialSigner` or `TransactionPartialSigner`, pass it directly to web3.js transaction signing APIs.
+- If the signer is a sending-only or modifying-only Kit signer, do not force it into web3.js `Transaction.sign(...)`; use a Kit-aware transaction flow or add an explicit boundary that handles modification/sending semantics.
+- If old code used `createNoopSigner(...)` only because web3.js could not accept Kit signers, remove the noop wrapper and pass the real signer where possible.
 
 ### Async boundary changes
+
 - If a sync-looking call site already lives inside an async flow, convert it in place.
 - If the change crosses a public boundary, update that boundary contract instead of hiding the promise behind a partial shim.
 
 ### `bigint` handling
+
 - If a value represents a slot, count, block height, lamports-like threshold, or RPC context field, assume `bigint` may now appear.
 - If the app must interoperate with JSON, UI state, or libraries that reject `bigint`, convert at the boundary and assert safe range before narrowing.
 - If mocks or fixtures currently use plain numeric literals for those fields, fix the fixtures instead of weakening the production types.
 
 ### Commitment defaults
+
 - If old behavior implicitly relied on `finalized`, set `commitment: 'finalized'` explicitly.
 - If no code depends on finality-specific semantics, prefer the v3 defaults and remove redundant config.
 
 ### Readonly vs mutable
+
 - If an RPC result or nested collection is now readonly, spread or clone it before mutating.
 - If a local type only exists to mirror an SDK response, prefer deriving it from the SDK instead of re-declaring a mutable copy.
 
 ## Common Failure Modes
+
 - A migration updates imports but misses behavior changes, especially async transaction APIs and default commitment changes.
 - `bigint` values leak into code that expects `number`, causing subtle comparison, sort, serialization, or schema bugs.
 - `JSON.stringify(...)` or fixture helpers crash on `bigint` because migration work stopped at compile-time fixes.
 - Tests continue passing against mocks while live or integration flows still depend on old `finalized` defaults.
 - Buffer-based helper code keeps sliced or pooled views and accidentally signs or hashes the wrong bytes.
 - Sync-looking tests or stories still depend on `Keypair.generate().publicKey` and balloon into unnecessary async churn.
+- Code still treats `keypair.address` as an `Address` object and calls `.toBytes()`, `.equals(...)`, or `.toBase58()` on it.
+- Kit signer integrations wrap real signers in noop signers even though web3.js transaction signing can now accept partial signers directly.
+- Code assumes any Kit `TransactionSigner` can be passed to web3.js signing, even when the signer is sending-only or modifying-only.
 - App-local helper types drift from readonly SDK response shapes or more specific SDK value types.
 - Manual account decoders retain stale field sizes or enum assumptions after the public API moved to newer codec-backed definitions.
 - Deprecated aliases are treated as full legacy compatibility rather than a temporary bridge.
 
 ## Quality Bar
+
 The migration is not complete until these are true:
 
 1. Removed APIs are gone or shimmed at one controlled boundary.
 2. Async transaction and signing flows are awaited end to end.
-3. RPC numeric fields are handled intentionally, with `bigint` preserved or narrowed safely.
-4. Commitment-sensitive flows are explicit about `processed`, `confirmed`, or `finalized`.
-5. Byte-oriented paths no longer rely on implicit Buffer semantics.
-6. Readonly wrappers and SDK-specific value types are either preserved or intentionally converted at controlled boundaries.
-7. Program and account decode logic matches the current public API rather than stale manual layouts.
-8. Narrow tests or smoke checks cover each migrated slice, and the project typechecks afterward.
+3. Keypair identity usage chooses `address` for Kit signer strings and `publicKey` for web3.js `Address` methods.
+4. Kit signer integrations use direct partial signer support where possible instead of unnecessary noop adapters.
+5. RPC numeric fields are handled intentionally, with `bigint` preserved or narrowed safely.
+6. Commitment-sensitive flows are explicit about `processed`, `confirmed`, or `finalized`.
+7. Byte-oriented paths no longer rely on implicit Buffer semantics.
+8. Readonly wrappers and SDK-specific value types are either preserved or intentionally converted at controlled boundaries.
+9. Program and account decode logic matches the current public API rather than stale manual layouts.
+10. Narrow tests or smoke checks cover each migrated slice, and the project typechecks afterward.
 
 ## Completion Checklist
+
 1. Search for removed symbols and confirm each one is deleted or replaced.
 2. Search for legacy transaction and signature APIs and convert the remaining sync assumptions.
-3. Search for `PublicKey` internals and strict-input violations.
-4. Audit `Connection` call sites for omitted commitment and numeric-type assumptions.
-5. Audit byte-handling code for Buffer dependence and sliced-view hazards.
-6. Audit readonly RPC collections and SDK-shaped local helper types.
-7. Run the narrowest affected tests.
-8. Run project typecheck.
-9. Run one broader integration or app smoke path that exercises transaction sending and RPC reads.
+3. Search for `keypair.address.` call chains and move class-method usage to `keypair.publicKey`.
+4. Search for `PublicKey` internals and strict-input violations.
+5. Audit signer adapters and remove noop wrappers where direct Kit partial signer support is available.
+6. Audit `Connection` call sites for omitted commitment and numeric-type assumptions.
+7. Audit byte-handling code for Buffer dependence and sliced-view hazards.
+8. Audit readonly RPC collections and SDK-shaped local helper types.
+9. Run the narrowest affected tests.
+10. Run project typecheck.
+11. Run one broader integration or app smoke path that exercises transaction sending and RPC reads.
 
 ## Trigger Phrases
+
 This skill should activate for prompts such as:
+
 - "migrate this web3.js v1 app to v3"
 - "audit this Solana app for web3.js v3 compatibility"
 - "replace removed web3.js APIs"
 - "fix Address/PublicKey migration issues"
+- "fix Keypair.address migration issues"
+- "pass Kit signers to web3.js transactions"
+- "remove noop signer adapters"
 - "fix PublicKey.unique removal"
 - "sign messages with a keypair"
 - "verify signatures with a keypair or address"

--- a/src/keypair.ts
+++ b/src/keypair.ts
@@ -1,49 +1,86 @@
 import {
-  createKeyPairFromPrivateKeyBytes,
-  createKeyPairFromBytes,
+  createKeyPairSignerFromBytes,
+  createKeyPairSignerFromPrivateKeyBytes,
+  type Address as KitAddress,
+  type KeyPairSigner,
+  type MessagePartialSigner,
+  type MessagePartialSignerConfig,
+  type SignableMessage,
   signBytes,
   signatureBytes,
+  type SignatureDictionary,
+  type TransactionPartialSigner,
+  type TransactionPartialSignerConfig,
   verifySignature,
 } from '@solana/kit';
-import {assertKeyExporterIsAvailable} from '@solana/assertions';
 
 import {Address} from './address';
 import {toPackedUint8Array} from './utils/typed-array';
 
 /**
- * Keypair signer interface
+ * Legacy web3.js v1 signer shape: a `publicKey` paired with the 64-byte
+ * `secretKey` bytes. Accepted by transaction signing APIs as a fallback
+ * ed25519 signing path.
  */
-export interface Signer {
-  address: Address;
-
-  /** @deprecated Use `address` instead. */
+export interface Web3Signer {
   publicKey: Address;
-  secretKey?: Uint8Array;
-  signBytes(message: Uint8Array): Promise<Uint8Array>;
+  secretKey: Uint8Array;
 }
+
+/**
+ * Union of signer shapes accepted by web3.js transaction signing APIs.
+ *
+ * Includes the legacy {@link Web3Signer} shape as well as Kit
+ * `MessagePartialSigner` and `TransactionPartialSigner` values. Dispatch
+ * precedence is documented on `signTransactionMessageBytes` in
+ * `src/kit-adapters/signing.ts`.
+ */
+export type Signer =
+  | Web3Signer
+  | MessagePartialSigner
+  | TransactionPartialSigner;
+
+/**
+ * Subset of {@link Signer} accepted where transaction lifetime information
+ * is unavailable (e.g. `VersionedTransaction.sign`). Excludes
+ * `TransactionPartialSigner` because Kit transaction signing requires a
+ * lifetime constraint that `VersionedTransaction` does not carry.
+ */
+export type MessageSigner = Web3Signer | MessagePartialSigner;
+
+type SignableTransaction = Parameters<
+  TransactionPartialSigner['signTransactions']
+>[0][number];
 
 /**
  * An account keypair backed by WebCrypto.
  */
-export class Keypair implements Signer {
-  #keypair: CryptoKeyPair;
+export class Keypair implements Web3Signer, KeyPairSigner<KitAddress> {
+  // Required so that this class can be passed directly to Kit's
+  // `isKeyPairSigner` / `isMessagePartialSigner` / `isTransactionPartialSigner`
+  // type guards, which expect a `{[key: string]: unknown; address: Address}`
+  // shape.
+  //
+  // Side effect: any non-declared property access on a `Keypair` resolves to
+  // `unknown` instead of erroring. Accepted trade-off for Kit interop.
+  readonly [key: string]: unknown;
+
+  #signer: KeyPairSigner<KitAddress>;
   #privateKeyBytes: Uint8Array;
   #publicKeyBytes: Uint8Array;
 
   private constructor(
-    keypair: CryptoKeyPair,
+    signer: KeyPairSigner<KitAddress>,
     privateKeyBytes: Uint8Array,
     publicKeyBytes: Uint8Array,
   ) {
-    this.#keypair = keypair;
+    this.#signer = signer;
     this.#privateKeyBytes = privateKeyBytes;
     this.#publicKeyBytes = publicKeyBytes;
   }
 
   /**
-   * Generate a new random keypair
-   *
-   * @returns {Promise<Keypair>} Keypair
+   * Generate a new random keypair.
    */
   static async generate(): Promise<Keypair> {
     const privateKeyBytes = new Uint8Array(32);
@@ -52,46 +89,55 @@ export class Keypair implements Signer {
   }
 
   /**
-   * Create a keypair from a raw 64-byte secret key byte array.
+   * Create a keypair from a raw 64-byte secret key (32-byte private key
+   * followed by 32-byte public key).
    */
   static async fromSecretKey(secretKey: Uint8Array): Promise<Keypair> {
     const packedSecretKey = Uint8Array.from(secretKey);
-    const keypair = await createKeyPairFromBytes(packedSecretKey);
-    const publicKeyBytes = await exportCryptoKeyBytes(keypair.publicKey);
-    return new Keypair(keypair, packedSecretKey.slice(0, 32), publicKeyBytes);
+    const signer = await createKeyPairSignerFromBytes(packedSecretKey);
+    return new Keypair(
+      signer,
+      packedSecretKey.slice(0, 32),
+      packedSecretKey.slice(32),
+    );
   }
 
   /**
-   * Create a keypair from a 32-byte seed.
+   * Create a keypair from a 32-byte seed (private-key bytes).
    */
   static async fromSeed(seed: Uint8Array): Promise<Keypair> {
     const packedSeed = Uint8Array.from(seed);
-    const keypair = await createKeyPairFromPrivateKeyBytes(packedSeed);
-    const publicKeyBytes = await exportCryptoKeyBytes(keypair.publicKey);
-    return new Keypair(keypair, packedSeed, publicKeyBytes);
+    const signer = await createKeyPairSignerFromPrivateKeyBytes(packedSeed);
+    const publicKeyBytes = new Address(signer.address).toBytes();
+    return new Keypair(signer, packedSeed, publicKeyBytes);
   }
 
   /**
-   * The Address for this keypair
-   *
-   * @returns {Address} Address
+   * The base-58 address for this keypair as a Kit-branded address string.
+   * Use {@link publicKey} when you need the web3.js `Address` class methods.
    */
-  get address(): Address {
-    return new Address(this.#publicKeyBytes);
+  get address(): KitAddress {
+    return this.#signer.address;
   }
 
   /**
-   * Deprecated alias for `address`
-   *
-   * @returns {Address} Address
-   * @deprecated Use `address` instead.
+   * The public key for this keypair as a web3.js `Address` object, which
+   * supports `.toBytes()`, `.equals(...)`, `.toBase58()`, and
+   * `.verifySignature(...)`.
    */
   get publicKey(): Address {
     return new Address(this.#publicKeyBytes);
   }
 
   /**
-   * Returns this keypair's secret key bytes.
+   * The underlying WebCrypto `CryptoKeyPair`.
+   */
+  get keyPair(): CryptoKeyPair {
+    return this.#signer.keyPair;
+  }
+
+  /**
+   * Returns this keypair's 64-byte secret key bytes
    */
   get secretKey(): Uint8Array {
     const secretKey = new Uint8Array(64);
@@ -101,30 +147,53 @@ export class Keypair implements Signer {
   }
 
   /**
-   * Sign a message using this keypair.
+   * Sign one or more messages as a Kit `MessagePartialSigner`.
+   *
+   * Declared as an arrow-function field so callers can destructure
+   * (`const {signMessages} = keypair`) without losing `this` binding.
+   */
+  signMessages = (
+    messages: readonly SignableMessage[],
+    config?: MessagePartialSignerConfig,
+  ): Promise<readonly SignatureDictionary[]> => {
+    return this.#signer.signMessages(messages, config);
+  };
+
+  /**
+   * Sign one or more transactions as a Kit `TransactionPartialSigner`.
+   *
+   * Declared as an arrow-function field so callers can destructure
+   * (`const {signTransactions} = keypair`) without losing `this` binding.
+   */
+  signTransactions = (
+    transactions: readonly SignableTransaction[],
+    config?: TransactionPartialSignerConfig,
+  ): Promise<readonly SignatureDictionary[]> => {
+    return this.#signer.signTransactions(transactions, config);
+  };
+
+  /**
+   * Sign raw message bytes and return the 64-byte ed25519 signature.
    */
   async signBytes(message: Uint8Array): Promise<Uint8Array> {
-    const privateKey = this.#keypair.privateKey;
-    const signMessage = toPackedUint8Array(message);
-    return signBytes(privateKey, signMessage);
+    return signBytes(
+      this.#signer.keyPair.privateKey,
+      toPackedUint8Array(message),
+    );
   }
 
   /**
-   * Verify a signature using this keypair's public key.
+   * Verify a signature against the provided message using this keypair's
+   * public key.
    */
   async verifySignature(
     signature: Uint8Array,
     message: Uint8Array,
   ): Promise<boolean> {
-    const publicKey = this.#keypair.publicKey;
-    const verifySignatureBytes = signatureBytes(toPackedUint8Array(signature));
-    const verifyMessage = toPackedUint8Array(message);
-    return verifySignature(publicKey, verifySignatureBytes, verifyMessage);
+    return verifySignature(
+      this.#signer.keyPair.publicKey,
+      signatureBytes(toPackedUint8Array(signature)),
+      toPackedUint8Array(message),
+    );
   }
-}
-
-async function exportCryptoKeyBytes(key: CryptoKey): Promise<Uint8Array> {
-  assertKeyExporterIsAvailable();
-  const rawKey = await globalThis.crypto.subtle.exportKey('raw', key);
-  return new Uint8Array(rawKey);
 }

--- a/src/keypair.ts
+++ b/src/keypair.ts
@@ -4,13 +4,9 @@ import {
   type Address as KitAddress,
   type KeyPairSigner,
   type MessagePartialSigner,
-  type MessagePartialSignerConfig,
-  type SignableMessage,
   signBytes,
   signatureBytes,
-  type SignatureDictionary,
   type TransactionPartialSigner,
-  type TransactionPartialSignerConfig,
   verifySignature,
 } from '@solana/kit';
 
@@ -47,10 +43,6 @@ export type Signer =
  * lifetime constraint that `VersionedTransaction` does not carry.
  */
 export type MessageSigner = Web3Signer | MessagePartialSigner;
-
-type SignableTransaction = Parameters<
-  TransactionPartialSigner['signTransactions']
->[0][number];
 
 /**
  * An account keypair backed by WebCrypto.
@@ -95,11 +87,8 @@ export class Keypair implements Web3Signer, KeyPairSigner<KitAddress> {
   static async fromSecretKey(secretKey: Uint8Array): Promise<Keypair> {
     const packedSecretKey = Uint8Array.from(secretKey);
     const signer = await createKeyPairSignerFromBytes(packedSecretKey);
-    return new Keypair(
-      signer,
-      packedSecretKey.slice(0, 32),
-      packedSecretKey.slice(32),
-    );
+    const publicKeyBytes = new Address(signer.address).toBytes();
+    return new Keypair(signer, packedSecretKey.slice(0, 32), publicKeyBytes);
   }
 
   /**
@@ -152,12 +141,10 @@ export class Keypair implements Web3Signer, KeyPairSigner<KitAddress> {
    * Declared as an arrow-function field so callers can destructure
    * (`const {signMessages} = keypair`) without losing `this` binding.
    */
-  signMessages = (
-    messages: readonly SignableMessage[],
-    config?: MessagePartialSignerConfig,
-  ): Promise<readonly SignatureDictionary[]> => {
-    return this.#signer.signMessages(messages, config);
-  };
+  signMessages: KeyPairSigner<KitAddress>['signMessages'] = (
+    messages,
+    config,
+  ) => this.#signer.signMessages(messages, config);
 
   /**
    * Sign one or more transactions as a Kit `TransactionPartialSigner`.
@@ -165,12 +152,10 @@ export class Keypair implements Web3Signer, KeyPairSigner<KitAddress> {
    * Declared as an arrow-function field so callers can destructure
    * (`const {signTransactions} = keypair`) without losing `this` binding.
    */
-  signTransactions = (
-    transactions: readonly SignableTransaction[],
-    config?: TransactionPartialSignerConfig,
-  ): Promise<readonly SignatureDictionary[]> => {
-    return this.#signer.signTransactions(transactions, config);
-  };
+  signTransactions: KeyPairSigner<KitAddress>['signTransactions'] = (
+    transactions,
+    config,
+  ) => this.#signer.signTransactions(transactions, config);
 
   /**
    * Sign raw message bytes and return the 64-byte ed25519 signature.

--- a/src/kit-adapters/brand.ts
+++ b/src/kit-adapters/brand.ts
@@ -1,0 +1,28 @@
+import type {
+  Blockhash,
+  Nonce,
+  ReadonlyUint8Array,
+  TransactionMessageBytes,
+} from '@solana/kit';
+
+/**
+ * `Blockhash` and `Nonce` are distinct base58-string brands in Kit, but a
+ * durable nonce IS a blockhash-shaped value. TypeScript rejects the direct
+ * cross-brand cast, so the bypass is centralized here.
+ * @internal
+ */
+export function blockhashAsNonce(blockhash: Blockhash): Nonce {
+  return blockhash as unknown as Nonce;
+}
+
+/**
+ * `TransactionMessageBytes` is a branded `ReadonlyUint8Array<ArrayBuffer>`.
+ * We produce raw bytes from our legacy `Message` serializer and need to brand
+ * them for Kit consumption. Centralized here so the brand bypass is auditable.
+ * @internal
+ */
+export function asTransactionMessageBytes(
+  bytes: Uint8Array,
+): TransactionMessageBytes {
+  return bytes as ReadonlyUint8Array<ArrayBuffer> as TransactionMessageBytes;
+}

--- a/src/kit-adapters/signing.ts
+++ b/src/kit-adapters/signing.ts
@@ -1,0 +1,189 @@
+import {
+  assertIsTransactionWithinSizeLimit,
+  createSignableMessage,
+  type Address as KitAddress,
+  isMessagePartialSigner,
+  isTransactionPartialSigner,
+  type MessagePartialSigner,
+  signatureBytes,
+  type Transaction as KitTransaction,
+  type TransactionPartialSigner,
+  type TransactionWithLifetime,
+} from '@solana/kit';
+
+import {Address} from '../address';
+import type {Signer, Web3Signer} from '../keypair';
+import {SIGNATURE_LENGTH_IN_BYTES} from '../transaction/constants';
+import {sign} from '../utils/ed25519';
+import {toPackedUint8Array} from '../utils/typed-array';
+import {asTransactionMessageBytes} from './brand';
+
+type SignableTransaction = Parameters<
+  TransactionPartialSigner['signTransactions']
+>[0][number];
+
+type SignaturePair = Readonly<{
+  publicKey: Address;
+  signature?: Uint8Array | null;
+}>;
+
+type KitSignerCandidate = {
+  readonly [key: string]: unknown;
+  readonly address: KitAddress;
+};
+
+type SigningStrategy =
+  | {
+      kind: 'kit-tx';
+      signer: TransactionPartialSigner;
+      address: KitAddress;
+      lifetime: TransactionWithLifetime['lifetimeConstraint'];
+    }
+  | {
+      kind: 'kit-msg';
+      signer: MessagePartialSigner;
+      address: KitAddress;
+    }
+  | {
+      kind: 'secret-bytes';
+      secretKey: Uint8Array;
+    };
+
+/** @internal */
+export function getSignerPublicKey(signer: Signer): Address {
+  if ('publicKey' in signer) {
+    return signer.publicKey;
+  }
+  return new Address(signer.address);
+}
+
+/**
+ * Sign the serialized bytes of a legacy or versioned transaction message,
+ * dispatching to whichever signing mechanism the input signer provides.
+ *
+ * Strategy precedence (see {@link pickSigningStrategy}):
+ *   1. Kit `TransactionPartialSigner` + lifetime → `signTransactions`
+ *   2. Kit `MessagePartialSigner`                → `signMessages`
+ *   3. v1 `Web3Signer` (`secretKey` bytes)       → ed25519 fallback
+ * A Kit signer with only `signTransactions` and no lifetime is rejected.
+ *
+ * @internal
+ */
+export async function signTransactionMessageBytes(
+  signer: Signer,
+  messageBytes: Uint8Array,
+  requiredSignerPublicKeys: readonly Address[],
+  signatures: readonly SignaturePair[] = [],
+  lifetimeConstraint?: TransactionWithLifetime['lifetimeConstraint'],
+): Promise<Uint8Array | undefined> {
+  const strategy = pickSigningStrategy(signer, lifetimeConstraint);
+  switch (strategy.kind) {
+    case 'kit-tx': {
+      const [dict] = await strategy.signer.signTransactions([
+        buildSignableTransaction(
+          messageBytes,
+          requiredSignerPublicKeys,
+          signatures,
+          strategy.lifetime,
+        ),
+      ]);
+      return dict[strategy.address];
+    }
+    case 'kit-msg': {
+      const [dict] = await strategy.signer.signMessages([
+        createSignableMessage(toPackedUint8Array(messageBytes)),
+      ]);
+      return dict[strategy.address];
+    }
+    case 'secret-bytes':
+      return sign(messageBytes, strategy.secretKey);
+  }
+}
+
+function pickSigningStrategy(
+  signer: Signer,
+  lifetime: TransactionWithLifetime['lifetimeConstraint'] | undefined,
+): SigningStrategy {
+  const candidate = getKitSignerCandidate(signer);
+  if (candidate != null) {
+    const hasTransactionPartial = isTransactionPartialSigner(candidate);
+    const hasMessagePartial = isMessagePartialSigner(candidate);
+    if (hasTransactionPartial && lifetime != null) {
+      return {
+        kind: 'kit-tx',
+        signer: candidate,
+        address: candidate.address,
+        lifetime,
+      };
+    }
+    if (hasMessagePartial) {
+      return {
+        kind: 'kit-msg',
+        signer: candidate,
+        address: candidate.address,
+      };
+    }
+    if (hasTransactionPartial) {
+      throw new Error(
+        'TransactionPartialSigner support requires transaction lifetime information. Use a MessagePartialSigner-compatible signer or provide a transaction with a blockhash lifetime or nonce lifetime.',
+      );
+    }
+  }
+  if (isWeb3Signer(signer)) {
+    return {kind: 'secret-bytes', secretKey: signer.secretKey};
+  }
+  throw new Error('Unsupported signer input');
+}
+
+function getKitSignerCandidate(signer: Signer): KitSignerCandidate | undefined {
+  if ('address' in signer && typeof signer.address === 'string') {
+    return signer as Signer & KitSignerCandidate;
+  }
+  return undefined;
+}
+
+function isWeb3Signer(signer: Signer): signer is Web3Signer {
+  return (
+    'secretKey' in signer &&
+    (signer as Web3Signer).secretKey instanceof Uint8Array
+  );
+}
+
+function buildSignableTransaction(
+  messageBytes: Uint8Array,
+  requiredSignerPublicKeys: readonly Address[],
+  signatures: readonly SignaturePair[],
+  lifetimeConstraint: TransactionWithLifetime['lifetimeConstraint'],
+): SignableTransaction {
+  const transaction = {
+    lifetimeConstraint,
+    messageBytes: asTransactionMessageBytes(toPackedUint8Array(messageBytes)),
+    signatures: buildSignatureMap(requiredSignerPublicKeys, signatures),
+  } satisfies KitTransaction & TransactionWithLifetime;
+  assertIsTransactionWithinSizeLimit(transaction);
+  return transaction;
+}
+
+function buildSignatureMap(
+  requiredSignerPublicKeys: readonly Address[],
+  signatures: readonly SignaturePair[],
+): KitTransaction['signatures'] {
+  const signatureMap: KitTransaction['signatures'] = {};
+  for (const publicKey of requiredSignerPublicKeys) {
+    signatureMap[publicKey.toBase58()] = null;
+  }
+  for (const {publicKey, signature} of signatures) {
+    if (signature != null && !isAllZeroSignature(signature)) {
+      signatureMap[publicKey.toBase58()] = signatureBytes(signature);
+    }
+  }
+  return signatureMap;
+}
+
+function isAllZeroSignature(signature: Uint8Array): boolean {
+  if (signature.length !== SIGNATURE_LENGTH_IN_BYTES) return false;
+  for (let i = 0; i < signature.length; i++) {
+    if (signature[i] !== 0) return false;
+  }
+  return true;
+}

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -7,6 +7,7 @@ import {SYSVAR_RENT_PUBKEY} from './sysvar';
 import {sendAndConfirmTransaction} from './utils/send-and-confirm-transaction';
 import {sleep} from './utils/sleep';
 import type {Connection} from './connection';
+import {getSignerPublicKey} from './kit-adapters/signing';
 import type {Signer} from './keypair';
 import {SystemProgram} from './programs/system';
 import {toUint8ArrayView} from './utils/typed-array';
@@ -103,6 +104,8 @@ export class Loader {
     programId: Address,
     data: Uint8Array | Array<number>,
   ): Promise<boolean> {
+    const payerPubkey = getSignerPublicKey(payer);
+    const programPubkey = getSignerPublicKey(program);
     {
       const balanceNeeded = await connection.getMinimumBalanceForRentExemption(
         data.length,
@@ -110,7 +113,7 @@ export class Loader {
 
       // Fetch program account info to check if it has already been created
       const programInfo = await connection.getAccountInfo(
-        program.publicKey,
+        programPubkey,
         'confirmed',
       );
 
@@ -125,7 +128,7 @@ export class Loader {
           transaction = transaction || new Transaction();
           transaction.add(
             SystemProgram.allocate({
-              accountPubkey: program.publicKey,
+              accountPubkey: programPubkey,
               space: data.length,
             }),
           );
@@ -135,7 +138,7 @@ export class Loader {
           transaction = transaction || new Transaction();
           transaction.add(
             SystemProgram.assign({
-              accountPubkey: program.publicKey,
+              accountPubkey: programPubkey,
               programId,
             }),
           );
@@ -145,8 +148,8 @@ export class Loader {
           transaction = transaction || new Transaction();
           transaction.add(
             SystemProgram.transfer({
-              fromPubkey: payer.publicKey,
-              toPubkey: program.publicKey,
+              fromPubkey: payerPubkey,
+              toPubkey: programPubkey,
               lamports: BigInt(balanceNeeded) - programInfo.lamports,
             }),
           );
@@ -154,8 +157,8 @@ export class Loader {
       } else {
         transaction = new Transaction().add(
           SystemProgram.createAccount({
-            fromPubkey: payer.publicKey,
-            newAccountPubkey: program.publicKey,
+            fromPubkey: payerPubkey,
+            newAccountPubkey: programPubkey,
             lamports: Number(balanceNeeded > 0 ? balanceNeeded : 1),
             space: data.length,
             programId,
@@ -191,7 +194,13 @@ export class Loader {
       });
 
       const transaction = new Transaction().add({
-        keys: [{pubkey: program.publicKey, isSigner: true, isWritable: true}],
+        keys: [
+          {
+            pubkey: programPubkey,
+            isSigner: true,
+            isWritable: true,
+          },
+        ],
         programId,
         data,
       });
@@ -222,7 +231,7 @@ export class Loader {
 
       const transaction = new Transaction().add({
         keys: [
-          {pubkey: program.publicKey, isSigner: true, isWritable: true},
+          {pubkey: programPubkey, isSigner: true, isWritable: true},
           {pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false},
         ],
         programId,

--- a/src/transaction/legacy.ts
+++ b/src/transaction/legacy.ts
@@ -8,6 +8,7 @@ import {
   getShortU16Encoder,
   getStructDecoder,
   type Instruction as KitInstruction,
+  type TransactionWithLifetime,
 } from '@solana/kit';
 
 import {PACKET_DATA_SIZE, SIGNATURE_LENGTH_IN_BYTES} from './constants';
@@ -16,6 +17,12 @@ import {Message} from '../message';
 import {Address} from '../address';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
+import {toKitAddress} from '../kit-adapters/address';
+import {blockhashAsNonce} from '../kit-adapters/brand';
+import {
+  getSignerPublicKey,
+  signTransactionMessageBytes,
+} from '../kit-adapters/signing';
 import invariant from '../utils/assert';
 import type {Signer} from '../keypair';
 import type {CompiledInstruction} from '../message';
@@ -27,8 +34,6 @@ type MessageSignednessErrors = {
   invalid?: Address[];
   missing?: Address[];
 };
-
-type TransactionSigner = Signer;
 
 /**
  * Transaction signature as base-58 encoded string
@@ -703,23 +708,21 @@ export class Transaction {
    * rejected.
    *
    * The Transaction must be assigned a valid `recentBlockhash` before invoking this method
-   *
-   * @param {Array<Signer>} signers Array of signers that will sign the transaction
    */
-  async sign(...signers: Array<TransactionSigner>) {
+  async sign(...signers: Array<Signer>) {
     if (signers.length === 0) {
       throw new Error('No signers');
     }
 
-    const uniqueSigners = this._dedupeSigners(signers);
+    const resolved = this._resolveSigners(signers);
 
-    this.signatures = uniqueSigners.map(signer => ({
+    this.signatures = resolved.map(({publicKey}) => ({
       signature: null,
-      publicKey: signer.publicKey,
+      publicKey,
     }));
 
     const message = this._compile();
-    await this._partialSign(message, ...uniqueSigners);
+    await this._partialSign(message, resolved);
   }
 
   /**
@@ -728,45 +731,89 @@ export class Transaction {
    * instructions.
    *
    * All the caveats from the `sign` method apply to `partialSign`
-   *
-   * @param {Array<Signer>} signers Array of signers that will sign the transaction
    */
-  async partialSign(...signers: Array<TransactionSigner>) {
+  async partialSign(...signers: Array<Signer>) {
     if (signers.length === 0) {
       throw new Error('No signers');
     }
 
-    const uniqueSigners = this._dedupeSigners(signers);
-
+    const resolved = this._resolveSigners(signers);
     const message = this._compile();
-    await this._partialSign(message, ...uniqueSigners);
+    await this._partialSign(message, resolved);
   }
 
   /**
    * @internal
    */
-  async _partialSign(message: Message, ...signers: Array<Signer>) {
+  async _partialSign(
+    message: Message,
+    signers: ReadonlyArray<{signer: Signer; publicKey: Address}>,
+  ) {
     const signData = message.serialize();
-    for (const signer of signers) {
-      const signature = await signer.signBytes(signData);
-      this._addSignature(signer.publicKey, signature);
+    const signerPubkeys = message.accountKeys.slice(
+      0,
+      message.header.numRequiredSignatures,
+    );
+    const lifetimeConstraint = this._getLifetimeConstraint();
+    for (const {signer, publicKey} of signers) {
+      const signature = await signTransactionMessageBytes(
+        signer,
+        signData,
+        signerPubkeys,
+        this.signatures,
+        lifetimeConstraint,
+      );
+      if (signature !== undefined) {
+        this._addSignature(publicKey, signature);
+      }
     }
   }
 
-  private _dedupeSigners<T extends {publicKey: Address}>(
-    signers: Array<T>,
-  ): Array<T> {
-    const seen = new Set();
-    const uniqueSigners: Array<T> = [];
+  private _getLifetimeConstraint():
+    | TransactionWithLifetime['lifetimeConstraint']
+    | undefined {
+    if (this.nonceInfo != null) {
+      const nonceAccountAddress =
+        this.nonceInfo.nonceInstruction.keys[0]?.pubkey;
+      if (nonceAccountAddress == null) {
+        throw new Error(
+          'Transaction nonceInfo.nonceInstruction is missing a nonce account in keys[0]',
+        );
+      }
+      return {
+        nonce: blockhashAsNonce(this.nonceInfo.nonce),
+        nonceAccountAddress: toKitAddress(nonceAccountAddress),
+      };
+    }
+
+    if (
+      this.recentBlockhash != null &&
+      this.lastValidBlockHeight !== undefined
+    ) {
+      return {
+        blockhash: this.recentBlockhash,
+        lastValidBlockHeight: BigInt(this.lastValidBlockHeight),
+      };
+    }
+
+    return undefined;
+  }
+
+  private _resolveSigners(
+    signers: ReadonlyArray<Signer>,
+  ): Array<{signer: Signer; publicKey: Address}> {
+    const seen = new Set<string>();
+    const resolved: Array<{signer: Signer; publicKey: Address}> = [];
     for (const signer of signers) {
-      const key = signer.publicKey.toString();
+      const publicKey = getSignerPublicKey(signer);
+      const key = publicKey.toString();
       if (seen.has(key)) {
         continue;
       }
       seen.add(key);
-      uniqueSigners.push(signer);
+      resolved.push({signer, publicKey});
     }
-    return uniqueSigners;
+    return resolved;
   }
 
   /**

--- a/src/transaction/versioned.ts
+++ b/src/transaction/versioned.ts
@@ -12,7 +12,11 @@ import {
   type TransactionVersion,
 } from '@solana/kit';
 
-import type {Signer} from '../keypair';
+import {
+  getSignerPublicKey,
+  signTransactionMessageBytes,
+} from '../kit-adapters/signing';
+import type {MessageSigner} from '../keypair';
 import assert from '../utils/assert';
 import type {Address} from '../address';
 import {VersionedMessage} from '../message/versioned';
@@ -101,23 +105,35 @@ export class VersionedTransaction {
     );
   }
 
-  async sign(signers: Array<Signer>) {
+  async sign(signers: Array<MessageSigner>) {
     const messageData = this.message.serialize();
     const signerPubkeys = this.message.staticAccountKeys.slice(
       0,
       this.message.header.numRequiredSignatures,
     );
     for (const signer of signers) {
+      const signerPublicKey = getSignerPublicKey(signer);
       const signerIndex = signerPubkeys.findIndex(pubkey =>
-        pubkey.equals(signer.publicKey),
+        pubkey.equals(signerPublicKey),
       );
       assert(
         signerIndex >= 0,
-        `Cannot sign with non signer key ${signer.publicKey.toBase58()}`,
+        `Cannot sign with non signer key ${signerPublicKey.toBase58()}`,
       );
 
-      const signature = await signer.signBytes(messageData);
+      // `MessageSigner` excludes transaction-only Kit signers (those
+      // without `signMessages`), so the optional `signatures` and
+      // `lifetimeConstraint` parameters of `signTransactionMessageBytes`
+      // are unused on this path and we pass the defaults.
+      const signature = await signTransactionMessageBytes(
+        signer,
+        messageData,
+        signerPubkeys,
+      );
 
+      if (signature === undefined) {
+        continue;
+      }
       assert(
         signature.byteLength === SIGNATURE_LENGTH_IN_BYTES,
         'Signature must be 64 bytes long',

--- a/test/keypair.test.ts
+++ b/test/keypair.test.ts
@@ -1,4 +1,9 @@
 import {expect} from 'chai';
+import {
+  createSignableMessage,
+  createSignerFromKeyPair,
+  isKeyPairSigner,
+} from '@solana/signers';
 
 import {Keypair} from '../src';
 
@@ -51,13 +56,35 @@ describe('Keypair', function () {
     expect(first).to.eql(second);
   });
 
-  it('address getter matches publicKey and returns stable bytes', async () => {
+  it('address getter matches publicKey and returns a stable base58 string', async () => {
     const keypair = await Keypair.generate();
-    const first = Buffer.from(keypair.address.toBytes());
-    const second = Buffer.from(keypair.address.toBytes());
+    const first = keypair.address;
+    const second = keypair.address;
 
     expect(first).to.eql(second);
-    expect(first).to.eql(Buffer.from(keypair.publicKey.toBytes()));
+    expect(first).to.eql(keypair.publicKey.toBase58());
+  });
+
+  it('satisfies the Kit KeyPairSigner shape', async () => {
+    const keypair = await Keypair.generate();
+    const message = Buffer.from('kit signer message');
+    const [signatureDictionary] = await keypair.signMessages([
+      createSignableMessage(message),
+    ]);
+    const signature = signatureDictionary[keypair.address];
+
+    expect(isKeyPairSigner(keypair)).to.be.true;
+    expect(signature).not.to.be.undefined;
+    expect(await keypair.publicKey.verifySignature(signature!, message)).to.be
+      .true;
+  });
+
+  it('exposes the underlying CryptoKeyPair for signer conversion', async () => {
+    const keypair = await Keypair.generate();
+    const signer = await createSignerFromKeyPair(keypair.keyPair);
+
+    expect(isKeyPairSigner(signer)).to.be.true;
+    expect(signer.address).to.eq(keypair.address);
   });
 
   it('two generated keypairs differ', async () => {

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -4,10 +4,16 @@ import {
   getBlockhashDecoder,
   type Blockhash,
 } from '@solana/kit';
+import {
+  createNoopSigner,
+  generateKeyPairSigner,
+  type MessagePartialSigner,
+  type TransactionPartialSigner,
+} from '@solana/signers';
 import {expect} from 'chai';
 
 import {Connection} from '../src/connection';
-import {Keypair} from '../src/keypair';
+import {Keypair, type Signer} from '../src/keypair';
 import {Address} from '../src/address';
 import {
   Transaction,
@@ -31,7 +37,7 @@ const generateKeypair = async (): Promise<Keypair> => {
 };
 
 const generateBlockhash = async (): Promise<Blockhash> => {
-  return blockhash((await generateKeypair()).address.toBase58());
+  return blockhash((await generateKeypair()).address);
 };
 
 const expectPromiseToReject = async (
@@ -459,6 +465,198 @@ describe('Transaction', () => {
 
     await transaction.sign(signer);
     expect(transaction.signatures[0].signature).not.to.be.null;
+  });
+
+  it('keeps the exported Signer type compatible with v1 secretKey signers', async function () {
+    const signer = await generateKeypair();
+    const recipient = await generateKeypair();
+    const recentBlockhash = blockhash(signer.publicKey.toBase58());
+    const transfer = SystemProgram.transfer({
+      fromPubkey: signer.publicKey,
+      toPubkey: recipient.publicKey,
+      lamports: 123,
+    });
+    const legacySigner = {
+      publicKey: signer.publicKey,
+      secretKey: signer.secretKey,
+    } satisfies Signer;
+
+    const transaction = new Transaction({
+      blockhash: recentBlockhash,
+      lastValidBlockHeight: 9999,
+    }).add(transfer);
+
+    await transaction.sign(legacySigner);
+    expect(transaction.signatures[0].signature).not.to.be.null;
+    expect(await transaction.verifySignatures()).to.be.true;
+  });
+
+  it('signs with a raw Kit key pair signer', async function () {
+    const signer = await generateKeyPairSigner();
+    const signerPublicKey = new Address(signer.address);
+    const recipient = await generateKeypair();
+    const recentBlockhash = blockhash(signer.address);
+    const transfer = SystemProgram.transfer({
+      fromPubkey: signerPublicKey,
+      toPubkey: recipient.publicKey,
+      lamports: 123,
+    });
+
+    const transaction = new Transaction({
+      blockhash: recentBlockhash,
+      lastValidBlockHeight: 9999,
+    }).add(transfer);
+
+    await transaction.sign(signer);
+    expect(transaction.signatures[0].signature).not.to.be.null;
+    expect(await transaction.verifySignatures()).to.be.true;
+  });
+
+  it('passes blockhash lifetime to Kit transaction partial signers', async function () {
+    const keyPairSigner = await generateKeyPairSigner();
+    const signerPublicKey = new Address(keyPairSigner.address);
+    const recipient = await generateKeypair();
+    const recentBlockhash = blockhash(keyPairSigner.address);
+    let lifetimeConstraint: unknown;
+    const transactionOnlySigner = {
+      address: keyPairSigner.address,
+      signTransactions: async transactions => {
+        lifetimeConstraint = transactions[0].lifetimeConstraint;
+        return keyPairSigner.signTransactions(transactions);
+      },
+    } satisfies TransactionPartialSigner;
+    const transfer = SystemProgram.transfer({
+      fromPubkey: signerPublicKey,
+      toPubkey: recipient.publicKey,
+      lamports: 123,
+    });
+
+    const transaction = new Transaction({
+      blockhash: recentBlockhash,
+      lastValidBlockHeight: 9999,
+    }).add(transfer);
+
+    await transaction.sign(transactionOnlySigner);
+    expect(lifetimeConstraint).to.deep.equal({
+      blockhash: recentBlockhash,
+      lastValidBlockHeight: 9999n,
+    });
+    expect(transaction.signatures[0].signature).not.to.be.null;
+    expect(await transaction.verifySignatures()).to.be.true;
+  });
+
+  it('passes nonce lifetime to Kit transaction partial signers', async function () {
+    const keyPairSigner = await generateKeyPairSigner();
+    const signerPublicKey = new Address(keyPairSigner.address);
+    const recipient = await generateKeypair();
+    const nonceAccount = await generateKeypair();
+    const nonce = blockhash(recipient.publicKey.toBase58());
+    const nonceInfo = {
+      nonce,
+      nonceInstruction: SystemProgram.nonceAdvance({
+        noncePubkey: nonceAccount.publicKey,
+        authorizedPubkey: signerPublicKey,
+      }),
+    };
+    let lifetimeConstraint: unknown;
+    const transactionOnlySigner = {
+      address: keyPairSigner.address,
+      signTransactions: async transactions => {
+        lifetimeConstraint = transactions[0].lifetimeConstraint;
+        return keyPairSigner.signTransactions(transactions);
+      },
+    } satisfies TransactionPartialSigner;
+    const transfer = SystemProgram.transfer({
+      fromPubkey: signerPublicKey,
+      toPubkey: recipient.publicKey,
+      lamports: 123,
+    });
+
+    const transaction = new Transaction({nonceInfo}).add(transfer);
+
+    await transaction.sign(transactionOnlySigner);
+    expect(lifetimeConstraint).to.deep.equal({
+      nonce,
+      nonceAccountAddress: nonceAccount.address,
+    });
+    expect(transaction.signatures[0].signature).not.to.be.null;
+    expect(await transaction.verifySignatures()).to.be.true;
+  });
+
+  it('rejects transaction-only Kit signers when transaction lifetime is unavailable', async function () {
+    const keyPairSigner = await generateKeyPairSigner();
+    const signerPublicKey = new Address(keyPairSigner.address);
+    const recipient = await generateKeypair();
+    const recentBlockhash = blockhash(keyPairSigner.address);
+    const transactionOnlySigner = {
+      address: keyPairSigner.address,
+      signTransactions: keyPairSigner.signTransactions,
+    } satisfies TransactionPartialSigner;
+    const transfer = SystemProgram.transfer({
+      fromPubkey: signerPublicKey,
+      toPubkey: recipient.publicKey,
+      lamports: 123,
+    });
+
+    const transaction = new Transaction({recentBlockhash}).add(transfer);
+
+    await expectPromiseToReject(
+      transaction.sign(transactionOnlySigner),
+      'TransactionPartialSigner support requires transaction lifetime information. Use a MessagePartialSigner-compatible signer or provide a transaction with a blockhash lifetime or nonce lifetime.',
+    );
+  });
+
+  it('allows noop Kit partial signers to leave signatures empty', async function () {
+    const signer = await generateKeypair();
+    const recipient = await generateKeypair();
+    const recentBlockhash = blockhash(signer.address);
+    const transfer = SystemProgram.transfer({
+      fromPubkey: signer.publicKey,
+      toPubkey: recipient.publicKey,
+      lamports: 123,
+    });
+
+    const transaction = new Transaction({
+      blockhash: recentBlockhash,
+      lastValidBlockHeight: 9999,
+    }).add(transfer);
+
+    await transaction.sign(createNoopSigner(signer.address));
+    expect(transaction.signatures).to.have.length(1);
+    expect(transaction.signatures[0].publicKey.equals(signer.publicKey)).to.be
+      .true;
+    expect(transaction.signatures[0].signature).to.be.null;
+  });
+
+  it('signs with a Keychain-style Kit partial signer', async function () {
+    const keyPairSigner = await generateKeyPairSigner();
+    const signerPublicKey = new Address(keyPairSigner.address);
+    const recipient = await generateKeypair();
+    const recentBlockhash = blockhash(keyPairSigner.address);
+    const keychainSigner = {
+      address: keyPairSigner.address,
+      isAvailable: () => Promise.resolve(true),
+      signMessages: keyPairSigner.signMessages,
+      signTransactions: keyPairSigner.signTransactions,
+    } satisfies MessagePartialSigner &
+      TransactionPartialSigner & {
+        isAvailable(): Promise<boolean>;
+      };
+    const signerInput: Signer = keychainSigner;
+    const transfer = SystemProgram.transfer({
+      fromPubkey: signerPublicKey,
+      toPubkey: recipient.publicKey,
+      lamports: 123,
+    });
+
+    const transaction = new Transaction({
+      blockhash: recentBlockhash,
+      lastValidBlockHeight: 9999,
+    }).add(transfer);
+
+    await transaction.sign(signerInput);
+    expect(transaction.signatures[0].signature).not.to.be.null;
+    expect(await transaction.verifySignatures()).to.be.true;
   });
 
   describe('dedupe', () => {
@@ -1389,6 +1587,20 @@ describe('VersionedTransaction', () => {
     const recentBlockhash = await generateBlockhash();
     const message = new TransactionMessage({
       payerKey: payer.publicKey,
+      recentBlockhash,
+      instructions: [],
+    }).compileToV0Message();
+
+    const versionedTx = new VersionedTransaction(message);
+    await versionedTx.sign([payer]);
+    expect(Buffer.from(versionedTx.signatures[0])).to.not.eql(Buffer.alloc(64));
+  });
+
+  it('signs with a raw Kit key pair signer', async function () {
+    const payer = await generateKeyPairSigner();
+    const recentBlockhash = await generateBlockhash();
+    const message = new TransactionMessage({
+      payerKey: new Address(payer.address),
       recentBlockhash,
       instructions: [],
     }).compileToV0Message();


### PR DESCRIPTION
Makes Kit signers first-class citizens in v3 while preserving the v1 `Keypair` surface and method signatures.

## What changed
- `Keypair` structurally implements Kit's `KeyPairSigner<KitAddress>`. `isKeyPairSigner(keypair)` returns `true`, and `keypair` can be passed directly to any Kit API that accepts a `KeyPairSigner`, `MessagePartialSigner`, or `TransactionPartialSigner`.
- `Transaction.sign(...)`, `Transaction.partialSign(...)`, `VersionedTransaction.sign(...)`, `Connection.sendTransaction(...)`, `Connection.simulateTransaction(...)`, and `sendAndConfirmTransaction(...)` now accept `Signer`, a union of the legacy v1 shape (renamed `Web3Signer`) plus Kit's `MessagePartialSigner` and `TransactionPartialSigner`. The internal dispatcher picks the right strategy per signer.
- Bridge code lives in `src/kit-adapters/signing.ts` (dispatcher + strategy) and `src/kit-adapters/brand.ts` (centralized `Blockhash → Nonce` and `TransactionMessageBytes` brand casts).

## Impact
Signing Interoperability with Web3js, Kit, Keychain:

```ts
  const web3Keypair = await Keypair.generate();
  const recipient = await Keypair.generate();
  const keychainSigner = await createKeychainSigner({});
  const kitSigner = await generateKeyPairSigner();
  // ...
  const tx = new Transaction()
    .add(
      getTransferSolInstruction({
        amount: TRANSFER_LAMPORTS,
        destination: recipientAddr.toBase58(),
        source: web3Keypair
      }),
    )
    .add(
      SystemProgram.transfer({
        fromPubkey: kitSignerPubkey,
        toPubkey: recipient.publicKey,
        lamports: TRANSFER_LAMPORTS,
      }),
    )
    .add(...)
    );
  // ...
  const signature = await sendAndConfirmTransaction(connection, tx, [
    web3Keypair,
    kitSigner,
    keychainSigner,
  ]);
```

Kind of annoying but to do this, `keypair.address` is now `KitAddress` (a branded base58 string), not an `Address` instance, to satisfy Kit's `KeyPairSigner`; use legacy `keypair.publicKey` whenever you need `Address` class methods. 

## v1 user impact

Same as `rc.0`:

```diff
- const kp = Keypair.generate();
+ const kp = await Keypair.generate();
```

## Test plan
- [x] `pnpm test:typecheck`
- [x] `pnpm test:lint`
- [x] `pnpm test:unit` (790 passing)

Closes DEV-601