### PR TITLE
fix: forward maxRetries for raw transactions

### DIFF
--- a/src/utils/send-and-confirm-raw-transaction.ts
+++ b/src/utils/send-and-confirm-raw-transaction.ts
@@ -79,6 +79,7 @@ export async function sendAndConfirmRawTransaction(
   const sendOptions = options && {
     skipPreflight: options.skipPreflight,
     preflightCommitment: options.preflightCommitment || options.commitment,
+    maxRetries: options.maxRetries,
     minContextSlot: options.minContextSlot,
   };
 

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -218,6 +218,43 @@ describe('Connection', function () {
     });
   }
 
+  it('sendAndConfirmRawTransaction forwards maxRetries', async () => {
+    const rawTransaction = Buffer.from([1, 2, 3]);
+    const signature = bs58.encode(Buffer.alloc(64, 1));
+    const sendRawTransactionStub = stub(
+      connection,
+      'sendRawTransaction',
+    ).resolves(signature);
+    const confirmTransactionStub = stub(
+      connection,
+      'confirmTransaction',
+    ).resolves({
+      context: {slot: 0},
+      value: {err: null},
+    } as any);
+
+    await sendAndConfirmRawTransaction(connection, rawTransaction, {
+      commitment: 'processed',
+      maxRetries: 7,
+      minContextSlot: 123,
+      skipPreflight: true,
+    });
+
+    expect(sendRawTransactionStub).to.have.been.calledOnceWithExactly(
+      rawTransaction,
+      {
+        skipPreflight: true,
+        preflightCommitment: 'processed',
+        maxRetries: 7,
+        minContextSlot: 123,
+      },
+    );
+    expect(confirmTransactionStub).to.have.been.calledOnceWithExactly(
+      signature,
+      'processed',
+    );
+  });
+
   describe('override HTTP agent', () => {
     let previousBrowserEnv: string | undefined;
     beforeEach(() => {


### PR DESCRIPTION
## Problem

`sendAndConfirmRawTransaction` accepts `ConfirmOptions`, including `maxRetries`, but the helper does not pass `maxRetries` through to `connection.sendRawTransaction`.

This means callers can provide `maxRetries` and have it silently ignored.

## Summary of Changes

- Forward `options.maxRetries` in the raw transaction send options.
- Add a regression test covering the pass-through behavior.

Fixes #3849