### PR TITLE
fix: validate lookup table decoder discriminators

### DIFF
--- a/src/programs/address-lookup-table/index.ts
+++ b/src/programs/address-lookup-table/index.ts
@@ -219,6 +219,10 @@ export class AddressLookupTableInstruction {
   ): FreezeLookupTableParams {
     this.checkProgramId(instruction.programId);
     this.checkKeysLength(instruction.keys, 2);
+    decodeData(
+      LOOKUP_TABLE_INSTRUCTION_LAYOUTS.FreezeLookupTable,
+      instruction.data,
+    );
 
     return {
       lookupTable: instruction.keys[0].pubkey,
@@ -231,6 +235,10 @@ export class AddressLookupTableInstruction {
   ): DeactivateLookupTableParams {
     this.checkProgramId(instruction.programId);
     this.checkKeysLength(instruction.keys, 2);
+    decodeData(
+      LOOKUP_TABLE_INSTRUCTION_LAYOUTS.DeactivateLookupTable,
+      instruction.data,
+    );
 
     return {
       lookupTable: instruction.keys[0].pubkey,

--- a/test/program-tests/address-lookup-table.test.ts
+++ b/test/program-tests/address-lookup-table.test.ts
@@ -159,6 +159,28 @@ describe('AddressLookupTableProgram', () => {
     );
   });
 
+  it('rejects cross-decoding freeze and deactivate instructions', () => {
+    const lookupTable = Keypair.generate().publicKey;
+    const authority = Keypair.generate().publicKey;
+    const params = {lookupTable, authority};
+
+    const freezeInstruction =
+      AddressLookupTableProgram.freezeLookupTable(params);
+    const deactivateInstruction =
+      AddressLookupTableProgram.deactivateLookupTable(params);
+
+    expect(() =>
+      AddressLookupTableInstruction.decodeFreezeLookupTable(
+        deactivateInstruction,
+      ),
+    ).to.throw('invalid instruction; instruction index mismatch 3 != 1');
+    expect(() =>
+      AddressLookupTableInstruction.decodeDeactivateLookupTable(
+        freezeInstruction,
+      ),
+    ).to.throw('invalid instruction; instruction index mismatch 1 != 3');
+  });
+
   if (process.env.TEST_LIVE) {
     it('live address lookup table actions', async () => {
       const connection = new Connection(url, 'confirmed');


### PR DESCRIPTION
#### Problem

The Freeze and Deactivate lookup table decoders only validated the program ID and account keys. Since both instructions have the same key shape, each decoder accepted the other instruction type.

#### Summary of Changes

- Validate instruction data against the expected layout in both decoders
- Add regression coverage for cross-decoding Freeze and Deactivate instructions

#### Testing

- Address lookup table program tests
- Full unit test suite
- TypeScript typecheck
- ESLint and Prettier

Fixes #3853
