### PR TITLE
fix: forward maxRetries and keep epoch powers above 2^31

### DIFF
--- a/src/epoch-schedule.ts
+++ b/src/epoch-schedule.ts
@@ -10,17 +10,15 @@ function trailingZeros(n: number) {
   return trailingZeros;
 }
 
-// Returns the smallest power of two greater than or equal to n
+// Returns the smallest power of two greater than or equal to n.
+// Do not use bitwise operators here: JS ToInt32 truncates values at 2^31.
 function nextPowerOfTwo(n: number) {
-  if (n === 0) return 1;
-  n--;
-  n |= n >> 1;
-  n |= n >> 2;
-  n |= n >> 4;
-  n |= n >> 8;
-  n |= n >> 16;
-  n |= n >> 32;
-  return n + 1;
+  if (n <= 1) return 1;
+  let power = 1;
+  while (power < n) {
+    power *= 2;
+  }
+  return power;
 }
 
 /**

--- a/src/utils/send-and-confirm-raw-transaction.ts
+++ b/src/utils/send-and-confirm-raw-transaction.ts
@@ -79,6 +79,7 @@ export async function sendAndConfirmRawTransaction(
   const sendOptions = options && {
     skipPreflight: options.skipPreflight,
     preflightCommitment: options.preflightCommitment || options.commitment,
+    maxRetries: options.maxRetries,
     minContextSlot: options.minContextSlot,
   };
 

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -218,6 +218,43 @@ describe('Connection', function () {
     });
   }
 
+  it('sendAndConfirmRawTransaction forwards maxRetries', async () => {
+    const rawTransaction = Buffer.from([1, 2, 3]);
+    const signature = bs58.encode(Buffer.alloc(64, 1));
+    const sendRawTransactionStub = stub(
+      connection,
+      'sendRawTransaction',
+    ).resolves(signature);
+    const confirmTransactionStub = stub(
+      connection,
+      'confirmTransaction',
+    ).resolves({
+      context: {slot: 0},
+      value: {err: null},
+    } as any);
+
+    await sendAndConfirmRawTransaction(connection, rawTransaction, {
+      commitment: 'processed',
+      maxRetries: 7,
+      minContextSlot: 123,
+      skipPreflight: true,
+    });
+
+    expect(sendRawTransactionStub).to.have.been.calledOnceWithExactly(
+      rawTransaction,
+      {
+        skipPreflight: true,
+        preflightCommitment: 'processed',
+        maxRetries: 7,
+        minContextSlot: 123,
+      },
+    );
+    expect(confirmTransactionStub).to.have.been.calledOnceWithExactly(
+      signature,
+      'processed',
+    );
+  });
+
   describe('override HTTP agent', () => {
     let previousBrowserEnv: string | undefined;
     beforeEach(() => {

--- a/test/epoch-schedule.test.ts
+++ b/test/epoch-schedule.test.ts
@@ -43,4 +43,20 @@ describe('EpochSchedule', () => {
       firstNormalSlot + 3 * slotsPerEpoch - 1,
     );
   });
+
+  it('warmup epoch/slot conversion stays exact past the signed 32-bit boundary', () => {
+    const slotsPerEpoch = 4294967296;
+    const firstNormalEpoch = 27;
+    const firstNormalSlot = 4294967264;
+    const epochSchedule = new EpochSchedule(
+      slotsPerEpoch,
+      0,
+      true,
+      firstNormalEpoch,
+      firstNormalSlot,
+    );
+
+    expect(epochSchedule.getEpochAndSlotIndex(2147483616)).to.be.eql([26, 0]);
+    expect(epochSchedule.getFirstSlotInEpoch(26)).to.be.equal(2147483616);
+  });
 });


### PR DESCRIPTION
## Summary
- `sendAndConfirmRawTransaction` accepted `ConfirmOptions.maxRetries` but rebuilt `SendOptions` without it, so `Connection.sendRawTransaction` never put the caller's retry count on the RPC. `sendAndConfirmTransaction` already forwards it.
- `EpochSchedule.nextPowerOfTwo` used signed 32-bit bitwise ops. A self-consistent warmup schedule past that boundary classified epoch 26's first slot as epoch -6.

Fixes #3849
Fixes #3854

## Test plan
- [x] `sendAndConfirmRawTransaction` stub test: `maxRetries: 7` is passed through to `sendRawTransaction`
- [x] `EpochSchedule` warmup conversion at `{slotsPerEpoch: 4294967296, firstNormalEpoch: 27, firstNormalSlot: 4294967264, slot: 2147483616}` returns `[26, 0]`
