### PR TITLE
fix: forward maxRetries in sendAndConfirmRawTransaction

### DIFF
--- a/src/utils/send-and-confirm-raw-transaction.ts
+++ b/src/utils/send-and-confirm-raw-transaction.ts
@@ -79,6 +79,7 @@ export async function sendAndConfirmRawTransaction(
   const sendOptions = options && {
     skipPreflight: options.skipPreflight,
     preflightCommitment: options.preflightCommitment || options.commitment,
+    maxRetries: options.maxRetries,
     minContextSlot: options.minContextSlot,
   };
 

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -1289,41 +1289,6 @@ describe('Connection', function () {
         ]);
       });
 
-      it('sendAndConfirmRawTransaction forwards maxRetries in sendOptions', async () => {
-        connection = new Connection(url, 'confirmed');
-        const sendRawTransactionStub = stub(
-          connection,
-          'sendRawTransaction',
-        ).resolves('mockSignature' as any);
-        stub(connection, 'confirmTransaction').resolves({
-          context: {slot: 0},
-          value: {err: null},
-        } as any);
-
-        const dummyBuffer = Buffer.from('mockRawTx');
-        const confirmOptions = {
-          skipPreflight: true,
-          commitment: 'confirmed' as const,
-          maxRetries: 7,
-          minContextSlot: 100,
-        };
-
-        await sendAndConfirmRawTransaction(
-          connection,
-          dummyBuffer,
-          confirmOptions,
-        );
-
-        expect(sendRawTransactionStub.calledOnce).to.be.true;
-        const passedSendOptions = sendRawTransactionStub.firstCall.args[1];
-        expect(passedSendOptions).to.deep.equal({
-          skipPreflight: true,
-          preflightCommitment: 'confirmed',
-          maxRetries: 7,
-          minContextSlot: 100,
-        });
-      });
-
       it('Simulate transaction contains logs', async () => {
         const keypair = Keypair.generate();
         const destinationKeypair = Keypair.generate();
@@ -2327,6 +2292,43 @@ describe('Connection', function () {
       await expect(
         connection.getSignatureStatus(badTransactionSignature),
       ).to.be.rejectedWith(mockErrorMessage);
+    });
+  });
+
+  describe('send and confirm raw transaction', () => {
+    it('forwards maxRetries in sendOptions', async () => {
+      connection = new Connection(url, 'confirmed');
+      const sendRawTransactionStub = stub(
+        connection,
+        'sendRawTransaction',
+      ).resolves('mockSignature' as any);
+      stub(connection, 'confirmTransaction').resolves({
+        context: {slot: 0},
+        value: {err: null},
+      } as any);
+
+      const dummyBuffer = Buffer.from('mockRawTx');
+      const confirmOptions = {
+        skipPreflight: true,
+        commitment: 'confirmed' as const,
+        maxRetries: 7,
+        minContextSlot: 100,
+      };
+
+      await sendAndConfirmRawTransaction(
+        connection,
+        dummyBuffer,
+        confirmOptions,
+      );
+
+      expect(sendRawTransactionStub.calledOnce).to.be.true;
+      const passedSendOptions = sendRawTransactionStub.firstCall.args[1];
+      expect(passedSendOptions).to.deep.equal({
+        skipPreflight: true,
+        preflightCommitment: 'confirmed',
+        maxRetries: 7,
+        minContextSlot: 100,
+      });
     });
   });
 

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -1128,6 +1128,41 @@ describe('Connection', function () {
         ]);
       });
 
+      it('sendAndConfirmRawTransaction forwards maxRetries in sendOptions', async () => {
+        connection = new Connection(url, 'confirmed');
+        const sendRawTransactionStub = stub(
+          connection,
+          'sendRawTransaction',
+        ).resolves('mockSignature' as any);
+        stub(connection, 'confirmTransaction').resolves({
+          context: {slot: 0},
+          value: {err: null},
+        } as any);
+
+        const dummyBuffer = Buffer.from('mockRawTx');
+        const confirmOptions = {
+          skipPreflight: true,
+          commitment: 'confirmed' as const,
+          maxRetries: 7,
+          minContextSlot: 100,
+        };
+
+        await sendAndConfirmRawTransaction(
+          connection,
+          dummyBuffer,
+          confirmOptions,
+        );
+
+        expect(sendRawTransactionStub.calledOnce).to.be.true;
+        const passedSendOptions = sendRawTransactionStub.firstCall.args[1];
+        expect(passedSendOptions).to.deep.equal({
+          skipPreflight: true,
+          preflightCommitment: 'confirmed',
+          maxRetries: 7,
+          minContextSlot: 100,
+        });
+      });
+
       it('sendAndConfirmTransaction skipPreflight: true', async () => {
         const keypair = Keypair.generate();
         const destinationKeypair = Keypair.generate();
@@ -1287,6 +1322,41 @@ describe('Connection', function () {
             /Program 11111111111111111111111111111111 failed: custom program error: 0x1/,
           ),
         ]);
+      });
+
+      it('sendAndConfirmRawTransaction forwards maxRetries in sendOptions', async () => {
+        connection = new Connection(url, 'confirmed');
+        const sendRawTransactionStub = stub(
+          connection,
+          'sendRawTransaction',
+        ).resolves('mockSignature' as any);
+        stub(connection, 'confirmTransaction').resolves({
+          context: {slot: 0},
+          value: {err: null},
+        } as any);
+
+        const dummyBuffer = Buffer.from('mockRawTx');
+        const confirmOptions = {
+          skipPreflight: true,
+          commitment: 'confirmed' as const,
+          maxRetries: 7,
+          minContextSlot: 100,
+        };
+
+        await sendAndConfirmRawTransaction(
+          connection,
+          dummyBuffer,
+          confirmOptions,
+        );
+
+        expect(sendRawTransactionStub.calledOnce).to.be.true;
+        const passedSendOptions = sendRawTransactionStub.firstCall.args[1];
+        expect(passedSendOptions).to.deep.equal({
+          skipPreflight: true,
+          preflightCommitment: 'confirmed',
+          maxRetries: 7,
+          minContextSlot: 100,
+        });
       });
 
       it('Simulate transaction contains logs', async () => {

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -1128,41 +1128,6 @@ describe('Connection', function () {
         ]);
       });
 
-      it('sendAndConfirmRawTransaction forwards maxRetries in sendOptions', async () => {
-        connection = new Connection(url, 'confirmed');
-        const sendRawTransactionStub = stub(
-          connection,
-          'sendRawTransaction',
-        ).resolves('mockSignature' as any);
-        stub(connection, 'confirmTransaction').resolves({
-          context: {slot: 0},
-          value: {err: null},
-        } as any);
-
-        const dummyBuffer = Buffer.from('mockRawTx');
-        const confirmOptions = {
-          skipPreflight: true,
-          commitment: 'confirmed' as const,
-          maxRetries: 7,
-          minContextSlot: 100,
-        };
-
-        await sendAndConfirmRawTransaction(
-          connection,
-          dummyBuffer,
-          confirmOptions,
-        );
-
-        expect(sendRawTransactionStub.calledOnce).to.be.true;
-        const passedSendOptions = sendRawTransactionStub.firstCall.args[1];
-        expect(passedSendOptions).to.deep.equal({
-          skipPreflight: true,
-          preflightCommitment: 'confirmed',
-          maxRetries: 7,
-          minContextSlot: 100,
-        });
-      });
-
       it('sendAndConfirmTransaction skipPreflight: true', async () => {
         const keypair = Keypair.generate();
         const destinationKeypair = Keypair.generate();


### PR DESCRIPTION
## Summary

Fixes #3849.

`sendAndConfirmRawTransaction` accepts `ConfirmOptions` (which specifies `maxRetries`), but when constructing `sendOptions` before calling `connection.sendRawTransaction`, it omitted `maxRetries: options.maxRetries`. As a result, caller-specified `maxRetries` configurations were silently dropped on raw transactions, forcing the node to fall back to its default retry policy.

## What Changed

- Forward `maxRetries: options.maxRetries` in `sendAndConfirmRawTransaction` (`src/utils/send-and-confirm-raw-transaction.ts`), aligning it with `sendAndConfirmTransaction`.
- Added unit test in `test/connection.test.ts` verifying that `sendAndConfirmRawTransaction` propagates `maxRetries` into the `sendOptions` object passed to `connection.sendRawTransaction`.
