### PR TITLE
fix: stop subscription teardown retry when the websocket is already closed

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -80,6 +80,18 @@ const BufferFromRawAccountData = coerce(
 export const BLOCKHASH_CACHE_TIMEOUT_MS = 30 * 1000;
 
 /**
+ * RpcWebSocketClient.call/notify reject with this message when the underlying
+ * socket is not OPEN, without emitting `close` or bumping the connection
+ * generation. Matching on the message is what the client actually throws.
+ */
+function isRpcSocketClosedError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.message.includes('socket was not `CONNECTING` or `OPEN`')
+  );
+}
+
+/**
  * HACK.
  * Copied from rpc-websockets/dist/lib/client.
  * Otherwise, `yarn build` fails with:
@@ -6272,11 +6284,16 @@ export class Connection {
                 if (!isCurrentConnectionStillActive()) {
                   return;
                 }
-                // TODO: Maybe add an 'errored' state or a retry limit?
                 this._setSubscription(hash, {
                   ...subscription,
                   state: 'pending',
                 });
+                if (isRpcSocketClosedError(e)) {
+                  // Wait for reconnect; retrying while the socket is already
+                  // closed loops without ever changing generation.
+                  return;
+                }
+                // TODO: Maybe add an 'errored' state or a retry limit?
                 await this._updateSubscriptions();
               }
             })();
@@ -6321,6 +6338,18 @@ export class Connection {
                       console.error(`${unsubscribeMethod} error:`, e.message);
                     }
                     if (!isCurrentConnectionStillActive()) {
+                      return;
+                    }
+                    // call() rejects locally when the socket is CLOSING/CLOSED
+                    // without bumping the connection generation. Retrying that
+                    // as a still-subscribed teardown loops until the process
+                    // is killed. The server is unreachable, so finish locally.
+                    if (isRpcSocketClosedError(e)) {
+                      this._setSubscription(hash, {
+                        ...subscription,
+                        state: 'unsubscribed',
+                      });
+                      await this._updateSubscriptions();
                       return;
                     }
                     // TODO: Maybe add an 'errored' state or a retry limit?

--- a/test/connection-subscriptions.test.ts
+++ b/test/connection-subscriptions.test.ts
@@ -525,6 +525,24 @@ describe('Subscriptions', () => {
                   );
                 });
               });
+              describe('if that unsubscribe fails because the socket is already closed', () => {
+                beforeEach(async () => {
+                  stubbedSocket.call.resetHistory();
+                  const unsubscribeMethod = subscriptionMethod.replace(
+                    'Subscribe',
+                    'Unsubscribe',
+                  );
+                  await fatalUnsubscribe(
+                    new Error(
+                      `Tried to call a JSON-RPC method \`${unsubscribeMethod}\` but the socket was not \`CONNECTING\` or \`OPEN\` (\`readyState\` was 2)`,
+                    ),
+                  );
+                });
+                it('does not retry the unsubscribe request', async () => {
+                  await Promise.resolve();
+                  expect(stubbedSocket.call).not.to.have.been.called;
+                });
+              });
               describe('then having the socket connection error', () => {
                 beforeEach(() => {
                   stubbedSocket.emit(


### PR DESCRIPTION
#### Problem

`Connection._updateSubscriptions()` retries an unsubscribe after `RpcWebSocketClient.call` rejects. That client rejects locally when `readyState` is not OPEN, without emitting `close` and without bumping `_rpcWebSocketGeneration`.

The catch path then treats the connection as still active, resets the subscription to `subscribed`, and recurses. The same call fails again, which matches the production loop in #3761 (`accountUnsubscribe` / `readyState was 2`).

#### Summary of Changes

- If unsubscribe fails because the socket is already closed, finish the teardown locally instead of retrying.
- If subscribe fails for the same reason, leave the subscription `pending` and wait for reconnect instead of spinning.
- Transient RPC failures still retry, which existing tests cover.
- Adds a regression test for the closed-socket unsubscribe path.

Fixes #3761