### PR TITLE
fix: keep onSignatureWithOptions subscribed after received notifications

### DIFF
--- a/src/connection.ts
+++ b/src/connection.ts
@@ -6889,6 +6889,11 @@ export class Connection {
       {
         callback: (notification, context) => {
           callback(notification, context);
+          // Received notifications are not final. Keep the listener so the
+          // later processed status can still be delivered, matching onSignature.
+          if (notification.type !== 'status') {
+            return;
+          }
           // Signatures subscriptions are auto-removed by the RPC service
           // so no need to explicitly send an unsubscribe message.
           try {

--- a/test/connection-subscriptions.test.ts
+++ b/test/connection-subscriptions.test.ts
@@ -847,6 +847,66 @@ describe('Subscriptions', () => {
       });
     });
   });
+  describe('onSignatureWithOptions received notifications', () => {
+    let listenerCallback: SinonSpy;
+    const serverSubscriptionId = 0;
+    const testSignature = 'C2jDL4pcwpE2pP5EryTGn842JJUJTcurPGZUquQjySxK';
+    const getExpectedParams = () => [
+      testSignature,
+      {
+        commitment: connection.commitment || 'finalized',
+        enableReceivedNotification: true,
+      },
+    ];
+    beforeEach(() => {
+      stubbedSocket.call
+        .withArgs('signatureSubscribe', getExpectedParams())
+        .resolves(serverSubscriptionId);
+      listenerCallback = spy();
+      connection.onSignatureWithOptions(testSignature, listenerCallback, {
+        enableReceivedNotification: true,
+      });
+    });
+    describe('after a non-final received notification', () => {
+      beforeEach(() => {
+        stubbedSocket.emit('signatureNotification', {
+          subscription: serverSubscriptionId,
+          result: {
+            context: {slot: 11},
+            value: 'receivedSignature',
+          },
+        });
+      });
+      it('fires the listener callback', () => {
+        expect(listenerCallback).to.have.been.calledOnce;
+      });
+      it('does not unsubscribe after the received notification', () => {
+        expect(stubbedSocket.call).not.to.have.been.calledWith(
+          'signatureUnsubscribe',
+          [serverSubscriptionId],
+        );
+      });
+      describe('then a processed status notification', () => {
+        beforeEach(() => {
+          listenerCallback.resetHistory();
+          stubbedSocket.emit('signatureNotification', {
+            subscription: serverSubscriptionId,
+            result: {
+              context: {slot: 12},
+              value: {err: null},
+            },
+          });
+        });
+        it('fires the listener callback again with the processed status', () => {
+          expect(listenerCallback).to.have.been.calledOnce;
+          expect(listenerCallback.firstCall.args[0]).to.deep.equal({
+            type: 'status',
+            result: {err: null},
+          });
+        });
+      });
+    });
+  });
   [
     undefined, // Let `Connection` use the default commitment
     'processed' as Commitment, // Override `Connection's` commitment


### PR DESCRIPTION
#### Problem

`onSignature` only removes its listener when the notification type is `status`. `onSignatureWithOptions` removed the listener after every callback.

With `enableReceivedNotification: true`, the first event is `received` and is not final. Unsubscribing there issues `signatureUnsubscribe` and drops the later processed status, so callers never see confirmation.

#### Summary of Changes

- Remove the `onSignatureWithOptions` listener only on `notification.type === 'status'`, matching `onSignature`.
- Regression test: a received notification still fires the callback, does not unsubscribe, and a following processed status is delivered.

Fixes #3855