### PR TITLE
ci: run the live validator integration tests on pull requests

### DIFF
--- a/.github/workflows/actions/lint-build-and-test/action.yml
+++ b/.github/workflows/actions/lint-build-and-test/action.yml
@@ -28,7 +28,6 @@ runs:
       shell: bash
       run: pnpm test:unit
 
-    # disabled due to broken test deprecated/removed symbols in for Agave v2
-    # - name: Run Integration Tests
-    #   shell: bash
-    #   run: pnpm test:live-with-test-validator
+    - name: Run Integration Tests
+      shell: bash
+      run: pnpm test:live

--- a/test/connection.test.ts
+++ b/test/connection.test.ts
@@ -7474,7 +7474,7 @@ describe('Connection', function () {
 
     const response = (await connection.getSignatureStatus(signature)).value;
     verifySignatureStatus(response, expectedStatusErr);
-  });
+  }).timeout(30 * 1000);
 
   if (mockServer) {
     it('returnData on simulateTransaction', async () => {


### PR DESCRIPTION
The PR workflow starts a test validator, but the integration test step was commented out — so the live tests never ran and CI paid the validator boot cost for nothing.

- Re-enable the step as `pnpm test:live` (reuses the validator the workflow already starts).
- Add the missing `.timeout(30 * 1000)` to `'transaction failure'` — it does two live airdrop+confirm round trips and tripped Mocha's 2s default. Without this, CI is red.

The Agave v2 breakage in the old disable comment no longer reproduces (tested against Agave 3.1.14).

Locally on this branch: `test:live` 859 passing in ~1m56s; unit/lint/prettier/compile/smoke all clean. Net cost is 21 live tests for ~2min CI.