### PR TITLE
feat: sign transactions with signers embedded in kit instructions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,10 @@ export * from './connection';
 export * from './epoch-schedule';
 export * from './errors';
 export * from './keypair';
+export {
+  getSignersFromInstructions,
+  type InstructionInput,
+} from './kit-adapters/instruction-plan';
 export * from './loader';
 export * from './message';
 export * from './nonce-account';

--- a/src/kit-adapters/embedded-signers.ts
+++ b/src/kit-adapters/embedded-signers.ts
@@ -1,0 +1,27 @@
+import type {MessagePartialSigner} from '@solana/kit';
+
+/**
+ * Sidecar storage for the signers embedded in the kit instructions a message
+ * or transaction message was built from.
+ */
+const EMBEDDED_SIGNERS = new WeakMap<
+  object,
+  ReadonlyArray<MessagePartialSigner>
+>();
+
+/** @internal */
+export function setEmbeddedSigners(
+  message: object,
+  signers: ReadonlyArray<MessagePartialSigner>,
+): void {
+  if (signers.length > 0) {
+    EMBEDDED_SIGNERS.set(message, signers);
+  }
+}
+
+/** @internal */
+export function getEmbeddedSigners(
+  message: object,
+): ReadonlyArray<MessagePartialSigner> {
+  return EMBEDDED_SIGNERS.get(message) ?? [];
+}

--- a/src/kit-adapters/instruction-plan.ts
+++ b/src/kit-adapters/instruction-plan.ts
@@ -1,11 +1,16 @@
 import {
   flattenInstructionPlan,
+  getSignersFromInstruction,
   type Instruction as KitInstruction,
   type InstructionPlan,
+  type InstructionWithSigners,
   isInstructionPlan,
+  isMessagePartialSigner,
   isSingleInstructionPlan,
+  type MessagePartialSigner,
 } from '@solana/kit';
 
+import {isKitInstruction} from './instruction-guard';
 import type {TransactionInstruction} from '../transaction/legacy';
 
 /**
@@ -43,4 +48,28 @@ export function expandInstructionPlans<T>(
     }
   }
   return out;
+}
+
+/**
+ * Collects the message-capable signers embedded in kit `Instruction`s and
+ * `InstructionPlan`s, deduplicated by address. Legacy
+ * `TransactionInstruction`s carry no signer objects and contribute nothing.
+ */
+export function getSignersFromInstructions(
+  instructions: ReadonlyArray<InstructionInput>,
+): Array<MessagePartialSigner> {
+  const signers = new Map<string, MessagePartialSigner>();
+  for (const instruction of expandInstructionPlans(instructions)) {
+    if (!isKitInstruction(instruction)) {
+      continue;
+    }
+    for (const signer of getSignersFromInstruction(
+      instruction as InstructionWithSigners,
+    )) {
+      if (isMessagePartialSigner(signer) && !signers.has(signer.address)) {
+        signers.set(signer.address, signer);
+      }
+    }
+  }
+  return [...signers.values()];
 }

--- a/src/message/legacy.ts
+++ b/src/message/legacy.ts
@@ -14,10 +14,12 @@ import {
   MessageAddressTableLookup,
   MessageCompiledInstruction,
 } from './index';
+import {setEmbeddedSigners} from '../kit-adapters/embedded-signers';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
 import {
   expandInstructionPlans,
+  getSignersFromInstructions,
   type InstructionInput,
 } from '../kit-adapters/instruction-plan';
 import {CompiledKeys} from './compiled-keys';
@@ -140,12 +142,14 @@ export class Message {
           data: BASE58_DECODER.decode(ix.data),
         }),
       );
-    return new Message({
+    const message = new Message({
       header,
       accountKeys: staticAccountKeys,
       recentBlockhash: args.recentBlockhash,
       instructions: compiledInstructions,
     });
+    setEmbeddedSigners(message, getSignersFromInstructions(args.instructions));
+    return message;
   }
 
   isAccountSigner(index: number): boolean {

--- a/src/message/v0.ts
+++ b/src/message/v0.ts
@@ -12,10 +12,12 @@ import {
   MessageCompiledInstruction,
 } from './index';
 import {PublicKey} from '../publickey';
+import {setEmbeddedSigners} from '../kit-adapters/embedded-signers';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
 import {
   expandInstructionPlans,
+  getSignersFromInstructions,
   type InstructionInput,
 } from '../kit-adapters/instruction-plan';
 import {toPackedUint8Array, toUint8ArrayView} from '../utils/typed-array';
@@ -228,13 +230,15 @@ export class MessageV0 {
       accountKeysFromLookups,
     );
     const compiledInstructions = accountKeys.compileInstructions(instructions);
-    return new MessageV0({
+    const message = new MessageV0({
       header,
       staticAccountKeys,
       recentBlockhash: args.recentBlockhash,
       compiledInstructions,
       addressTableLookups,
     });
+    setEmbeddedSigners(message, getSignersFromInstructions(args.instructions));
+    return message;
   }
 
   serialize(): Uint8Array {

--- a/src/message/v1.ts
+++ b/src/message/v1.ts
@@ -18,10 +18,12 @@ import {
 
 import {MessageHeader, MessageCompiledInstruction} from './index';
 import {PublicKey} from '../publickey';
+import {setEmbeddedSigners} from '../kit-adapters/embedded-signers';
 import {toLegacyInstructionFields} from '../kit-adapters/instruction-fields';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
 import {
   expandInstructionPlans,
+  getSignersFromInstructions,
   type InstructionInput,
 } from '../kit-adapters/instruction-plan';
 import {toPackedUint8Array, toUint8ArrayView} from '../utils/typed-array';
@@ -205,13 +207,15 @@ export class MessageV1 {
     const [header, staticAccountKeys] = compiledKeys.getMessageComponents();
     const accountKeys = new MessageAccountKeys(staticAccountKeys);
     const compiledInstructions = accountKeys.compileInstructions(instructions);
-    return new MessageV1({
+    const message = new MessageV1({
       header,
       staticAccountKeys,
       recentBlockhash: args.recentBlockhash,
       compiledInstructions,
       transactionConfig: args.transactionConfig,
     });
+    setEmbeddedSigners(message, getSignersFromInstructions(args.instructions));
+    return message;
   }
 
   serialize(): Uint8Array {

--- a/src/transaction/message.ts
+++ b/src/transaction/message.ts
@@ -1,9 +1,14 @@
 import type {Blockhash} from '@solana/kit';
 
+import {
+  getEmbeddedSigners,
+  setEmbeddedSigners,
+} from '../kit-adapters/embedded-signers';
 import {fromKitInstruction} from '../kit-adapters/instruction';
 import {isKitInstruction} from '../kit-adapters/instruction-guard';
 import {
   expandInstructionPlans,
+  getSignersFromInstructions,
   type InstructionInput,
 } from '../kit-adapters/instruction-plan';
 import {AccountKeysFromLookups} from '../message/account-keys';
@@ -54,6 +59,7 @@ export class TransactionMessage {
     );
     this.recentBlockhash = args.recentBlockhash;
     this.transactionConfig = args.transactionConfig;
+    setEmbeddedSigners(this, getSignersFromInstructions(args.instructions));
   }
 
   static decompile(
@@ -146,22 +152,26 @@ export class TransactionMessage {
   }
 
   compileToLegacyMessage(): Message {
-    return Message.compile({
+    const message = Message.compile({
       payerKey: this.payerKey,
       recentBlockhash: this.recentBlockhash,
       instructions: this.instructions,
     });
+    setEmbeddedSigners(message, getEmbeddedSigners(this));
+    return message;
   }
 
   compileToV0Message(
     addressLookupTableAccounts?: AddressLookupTableAccount[],
   ): MessageV0 {
-    return MessageV0.compile({
+    const message = MessageV0.compile({
       payerKey: this.payerKey,
       recentBlockhash: this.recentBlockhash,
       instructions: this.instructions,
       addressLookupTableAccounts,
     });
+    setEmbeddedSigners(message, getEmbeddedSigners(this));
+    return message;
   }
 
   /**
@@ -175,11 +185,13 @@ export class TransactionMessage {
    * `transactionConfig` set on this `TransactionMessage`.
    */
   compileToV1Message(transactionConfig?: V1TransactionConfig): MessageV1 {
-    return MessageV1.compile({
+    const message = MessageV1.compile({
       payerKey: this.payerKey,
       recentBlockhash: this.recentBlockhash,
       instructions: this.instructions,
       transactionConfig: transactionConfig ?? this.transactionConfig,
     });
+    setEmbeddedSigners(message, getEmbeddedSigners(this));
+    return message;
   }
 }

--- a/src/transaction/versioned.ts
+++ b/src/transaction/versioned.ts
@@ -13,6 +13,7 @@ import {
   type TransactionVersion,
 } from '@solana/kit';
 
+import {getEmbeddedSigners} from '../kit-adapters/embedded-signers';
 import {
   getSignerPublicKey,
   signTransactionMessageBytes,
@@ -172,13 +173,31 @@ export class VersionedTransaction {
     );
   }
 
-  async sign(signers: Array<MessagePartialSigner>) {
+  /**
+   * Sign the transaction with the given signers, plus any required signers embedded in
+   * the kit instructions the message was compiled from. 
+   * Calling `sign()` with no arguments signs
+   * with the embedded signers alone.
+   */
+  async sign(signers: Array<MessagePartialSigner> = []) {
     const messageData = this.message.serialize();
     const signerPubkeys = this.message.staticAccountKeys.slice(
       0,
       this.message.header.numRequiredSignatures,
     );
+    const requiredSignerAddresses = new Set(
+      signerPubkeys.map(pubkey => pubkey.toBase58()),
+    );
+    const signersByAddress = new Map<string, MessagePartialSigner>();
+    for (const signer of getEmbeddedSigners(this.message)) {
+      if (requiredSignerAddresses.has(signer.address)) {
+        signersByAddress.set(signer.address, signer);
+      }
+    }
     for (const signer of signers) {
+      signersByAddress.set(signer.address, signer);
+    }
+    for (const signer of signersByAddress.values()) {
       const signerPublicKey = getSignerPublicKey(signer);
       const signerIndex = signerPubkeys.findIndex(pubkey =>
         pubkey.equals(signerPublicKey),

--- a/test/kit-adapter-tests/instruction-plan.test.ts
+++ b/test/kit-adapter-tests/instruction-plan.test.ts
@@ -1,0 +1,91 @@
+import {
+  AccountRole,
+  generateKeyPairSigner,
+  sequentialInstructionPlan,
+  singleInstructionPlan,
+  type AccountSignerMeta,
+  type Instruction as KitInstruction,
+  type KeyPairSigner,
+} from '@solana/kit';
+import {expect} from 'chai';
+
+import {getSignersFromInstructions} from '../../src/kit-adapters/instruction-plan';
+import {PublicKey} from '../../src/publickey';
+import {TransactionInstruction} from '../../src/transaction';
+import {getUniqueAddress} from '../utils/address';
+
+function makeKitIx(signers: ReadonlyArray<KeyPairSigner> = []): KitInstruction {
+  return {
+    accounts: signers.map(
+      (signer): AccountSignerMeta => ({
+        address: signer.address,
+        role: AccountRole.READONLY_SIGNER,
+        signer,
+      }),
+    ),
+    data: new Uint8Array([0]),
+    programAddress: getUniqueAddress().toBase58(),
+  };
+}
+
+describe('getSignersFromInstructions', () => {
+  it('collects signers embedded in kit instructions', async () => {
+    const signerA = await generateKeyPairSigner();
+    const signerB = await generateKeyPairSigner();
+
+    const signers = getSignersFromInstructions([
+      makeKitIx([signerA]),
+      makeKitIx([signerB]),
+    ]);
+
+    expect(signers.map(s => s.address)).to.have.members([
+      signerA.address,
+      signerB.address,
+    ]);
+  });
+
+  it('collects signers from instruction plans', async () => {
+    const signerA = await generateKeyPairSigner();
+    const signerB = await generateKeyPairSigner();
+
+    const signers = getSignersFromInstructions([
+      sequentialInstructionPlan([
+        makeKitIx([signerA]),
+        singleInstructionPlan(makeKitIx([signerB])),
+      ]),
+    ]);
+
+    expect(signers.map(s => s.address)).to.have.members([
+      signerA.address,
+      signerB.address,
+    ]);
+  });
+
+  it('deduplicates signers by address', async () => {
+    const signer = await generateKeyPairSigner();
+
+    const signers = getSignersFromInstructions([
+      makeKitIx([signer]),
+      makeKitIx([signer]),
+    ]);
+
+    expect(signers).to.have.length(1);
+    expect(signers[0].address).to.eq(signer.address);
+  });
+
+  it('ignores legacy instructions and kit instructions without signers', () => {
+    const legacyIx = new TransactionInstruction({
+      keys: [
+        {
+          isSigner: true,
+          isWritable: false,
+          pubkey: new PublicKey(getUniqueAddress().toBase58()),
+        },
+      ],
+      programId: getUniqueAddress(),
+      data: Buffer.from([1]),
+    });
+
+    expect(getSignersFromInstructions([legacyIx, makeKitIx()])).to.eql([]);
+  });
+});

--- a/test/transaction.test.ts
+++ b/test/transaction.test.ts
@@ -1597,6 +1597,118 @@ describe('VersionedTransaction', () => {
     expect(Buffer.from(versionedTx.signatures[0])).to.not.eql(Buffer.alloc(64));
   });
 
+  describe('sign with embedded kit signers', () => {
+    const makeKitIxWithSigners = (
+      signers: ReadonlyArray<MessagePartialSigner>,
+    ): KitInstruction => ({
+      accounts: signers.map(signer => ({
+        address: signer.address,
+        role: AccountRole.WRITABLE_SIGNER,
+        signer,
+      })),
+      data: new Uint8Array([0]),
+      programAddress: getUniqueAddress().toBase58(),
+    });
+
+    it('sign() with no arguments signs with the signers embedded in kit instructions', async () => {
+      const payer = await generateKeyPairSigner();
+      const embedded = await generateKeyPairSigner();
+      const recentBlockhash = await generateBlockhash();
+      const message = new TransactionMessage({
+        payerKey: new PublicKey(payer.address),
+        recentBlockhash,
+        instructions: [makeKitIxWithSigners([payer, embedded])],
+      }).compileToV1Message();
+
+      const transaction = new VersionedTransaction(message);
+      await transaction.sign();
+
+      expect(transaction.signatures).to.have.length(2);
+      for (const signature of transaction.signatures) {
+        expect(Buffer.from(signature)).to.not.eql(Buffer.alloc(64));
+      }
+    });
+
+    it('merges explicitly passed signers with embedded signers', async () => {
+      const payer = await generateKeyPairSigner();
+      const embedded = await generateKeyPairSigner();
+      const recentBlockhash = await generateBlockhash();
+      const message = new TransactionMessage({
+        payerKey: new PublicKey(payer.address),
+        recentBlockhash,
+        instructions: [singleInstructionPlan(makeKitIxWithSigners([embedded]))],
+      }).compileToV0Message();
+
+      const transaction = new VersionedTransaction(message);
+      await transaction.sign([payer]);
+
+      expect(transaction.signatures).to.have.length(2);
+      for (const signature of transaction.signatures) {
+        expect(Buffer.from(signature)).to.not.eql(Buffer.alloc(64));
+      }
+    });
+
+    it('signing a message compiled directly with MessageV1.compile uses embedded signers', async () => {
+      const payer = await generateKeyPairSigner();
+      const embedded = await generateKeyPairSigner();
+      const recentBlockhash = await generateBlockhash();
+      const message = MessageV1.compile({
+        payerKey: new PublicKey(payer.address),
+        recentBlockhash,
+        instructions: [makeKitIxWithSigners([payer, embedded])],
+      });
+
+      const transaction = new VersionedTransaction(message);
+      await transaction.sign();
+
+      expect(transaction.signatures).to.have.length(2);
+      for (const signature of transaction.signatures) {
+        expect(Buffer.from(signature)).to.not.eql(Buffer.alloc(64));
+      }
+    });
+
+    it('skips an embedded signer attached to a non-signer account, but throws for an explicit one', async () => {
+      const payer = await generateKeyPairSigner();
+      const nonSigner = await generateKeyPairSigner();
+      const recentBlockhash = await generateBlockhash();
+      const ix = {
+        accounts: [
+          {
+            address: payer.address,
+            role: AccountRole.WRITABLE_SIGNER,
+            signer: payer,
+          },
+          // kit's types forbid a signer on a non-signer role; forced here to
+          // simulate a malformed instruction from an untyped source
+          {
+            address: nonSigner.address,
+            role: AccountRole.READONLY,
+            signer: nonSigner,
+          } as unknown as NonNullable<KitInstruction['accounts']>[number],
+        ],
+        data: new Uint8Array([0]),
+        programAddress: getUniqueAddress().toBase58(),
+      } as KitInstruction;
+      const message = new TransactionMessage({
+        payerKey: new PublicKey(payer.address),
+        recentBlockhash,
+        instructions: [ix],
+      }).compileToV1Message();
+
+      const transaction = new VersionedTransaction(message);
+      await transaction.sign();
+      expect(transaction.signatures).to.have.length(1);
+      expect(Buffer.from(transaction.signatures[0])).to.not.eql(
+        Buffer.alloc(64),
+      );
+
+      await expectPromiseToReject(
+        transaction.sign([nonSigner]),
+        `Cannot sign with non signer key ${nonSigner.address}`,
+      );
+    });
+  });
+
   describe('addSignature', () => {
     let signer1: Keypair;
     let signer2: Keypair;


### PR DESCRIPTION
Opening as a draft to discuss design direction.


web3.js v3 accepts `@solana/kit` instructions and instruction plans but discards the signer objects. This is generally fine b/c users can just pass them through `.sign([])`, but some plans or instruction builders might internally create a necessary signer, eg Confidential Transfers ([src](https://github.com/solana-program/token-2022/blob/cd155ac7644c045454a835d99eba90fab20f7d54/clients/js/src/confidentialTransferHelpers.ts#L556)).

In Kit,`signTransactionMessageWithSigners` extracts embedded signers automatically--this PR pulls that same functionality into web3.js--allowing `.sign()` to use embedded signers inside of compiliation.
- uses aprivate `WeakMap` sidecar keyed by the message object 
- **`VersionedTransaction.sign()` now works with no arguments**, signing with the embedded signers. Explicitly passed signers still work and take precedence on address collisions.
- **`getSignersFromInstructions()` is exported** for callers who want the collected signer list directly.



### Some other ideas
- create a second sign method (e.g., `.signWithEmbedded` ) that does what's included in this PR w/o changing behavior of `sign`. 
- modify existing planners that have a generated signer and return the signers w/ the plan OR allow an optional signer argument for generated signers 
- create a second set of planners
- don't use planners
- just export a helper for signer extraction (still requires some work)


### Before / after
Here's a specific example I hit doing a confidential transfer using token-2022 confidential transfer plan:

**Before** :

```ts
import {
    flattenInstructionPlan,
    getSignersFromInstruction,
    isMessagePartialSigner,
    isSingleInstructionPlan,
    parseInstructionPlanInput,
    type InstructionPlanInput,
    type MessagePartialSigner,
} from '@solana/kit';

function instructionSigners(input: InstructionPlanInput): MessagePartialSigner[] {
    const signers = new Map<string, MessagePartialSigner>();
    for (const leaf of flattenInstructionPlan(parseInstructionPlanInput(input))) {
        if (!isSingleInstructionPlan(leaf)) continue;
        for (const signer of getSignersFromInstruction(leaf.instruction)) {
            if (isMessagePartialSigner(signer)) signers.set(signer.address, signer);
        }
    }
    return [...signers.values()];
}

const plan = await getCreateConfidentialTransferAccountInstructionPlan({ /* ... */ });
const message = MessageV1.compile({ payerKey, recentBlockhash, instructions: [plan] });
const transaction = new VersionedTransaction(message);
await transaction.sign([payer, ...instructionSigners(plan)]);
```

**After**:

```ts
const plan = await getCreateConfidentialTransferAccountInstructionPlan({ /* ... */ });
const message = MessageV1.compile({ payerKey, recentBlockhash, instructions: [plan] });
const transaction = new VersionedTransaction(message);
await transaction.sign([payer]);
```


Closes DEV-1014.