### PR TITLE
chore: release 1.99.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
       "diff@7": "^8.0.3",
       "serialize-javascript@<7.0.5": "^7.0.5",
       "@types/node@12": "^22.0.0",
-      "rpc-websockets": "9.0.4"
+      "rpc-websockets": "9.0.4",
+      "fast-uri@<3.1.6": "^3.1.6"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/web3.js",
-  "version": "1.99.0-beta.0",
+  "version": "1.99.0",
   "description": "Solana Javascript API",
   "keywords": [
     "api",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   serialize-javascript@<7.0.5: ^7.0.5
   '@types/node@12': ^22.0.0
   rpc-websockets: 9.0.4
+  fast-uri@<3.1.6: ^3.1.6
 
 importers:
 
@@ -2604,8 +2605,8 @@ packages:
   fast-stable-stringify@1.0.0:
     resolution: {integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -6473,7 +6474,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -7521,7 +7522,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.7: {}
 
   fastq@1.20.1:
     dependencies:


### PR DESCRIPTION
- Drops beta tag for 1.99.0 - will update to latest.
- Patch 2 Dependabot Alerts