### PR TITLE
fix: validate Freeze/Deactivate ALT decoder discriminators

### DIFF
--- a/src/programs/address-lookup-table/index.ts
+++ b/src/programs/address-lookup-table/index.ts
@@ -220,6 +220,11 @@ export class AddressLookupTableInstruction {
     this.checkProgramId(instruction.programId);
     this.checkKeysLength(instruction.keys, 2);
 
+    decodeData(
+      LOOKUP_TABLE_INSTRUCTION_LAYOUTS.FreezeLookupTable,
+      instruction.data,
+    );
+
     return {
       lookupTable: instruction.keys[0].pubkey,
       authority: instruction.keys[1].pubkey,
@@ -231,6 +236,11 @@ export class AddressLookupTableInstruction {
   ): DeactivateLookupTableParams {
     this.checkProgramId(instruction.programId);
     this.checkKeysLength(instruction.keys, 2);
+
+    decodeData(
+      LOOKUP_TABLE_INSTRUCTION_LAYOUTS.DeactivateLookupTable,
+      instruction.data,
+    );
 
     return {
       lookupTable: instruction.keys[0].pubkey,

--- a/test/program-tests/address-lookup-table.test.ts
+++ b/test/program-tests/address-lookup-table.test.ts
@@ -159,6 +159,34 @@ describe('AddressLookupTableProgram', () => {
     );
   });
 
+  it("decodeFreezeLookupTable rejects deactivate instruction", () => {
+    const lutAddress = Keypair.generate().publicKey;
+    const authorityPubkey = Keypair.generate().publicKey;
+
+    const instruction = AddressLookupTableProgram.deactivateLookupTable({
+      lookupTable: lutAddress,
+      authority: authorityPubkey,
+    });
+
+    expect(() =>
+      AddressLookupTableInstruction.decodeFreezeLookupTable(instruction),
+    ).to.throw(/instruction index mismatch/);
+  });
+
+  it("decodeDeactivateLookupTable rejects freeze instruction", () => {
+    const lutAddress = Keypair.generate().publicKey;
+    const authorityPubkey = Keypair.generate().publicKey;
+
+    const instruction = AddressLookupTableProgram.freezeLookupTable({
+      lookupTable: lutAddress,
+      authority: authorityPubkey,
+    });
+
+    expect(() =>
+      AddressLookupTableInstruction.decodeDeactivateLookupTable(instruction),
+    ).to.throw(/instruction index mismatch/);
+  });
+
   if (process.env.TEST_LIVE) {
     it('live address lookup table actions', async () => {
       const connection = new Connection(url, 'confirmed');


### PR DESCRIPTION
## Summary

`AddressLookupTableInstruction.decodeFreezeLookupTable` and `decodeDeactivateLookupTable` only checked the program id and key count. Freeze and Deactivate both use the same two-key layout, so each specific decoder would happily accept the other instruction kind. `decodeInstructionType` already reads the discriminator correctly, which made the mismatch easy to hit in tooling that mixes the generic type decoder with a specific one.

This was previously attempted in #3858 (closed unmerged). Opening a fresh PR against `maintenance/v1.x` with the same root-cause fix.

## What changed

- In `decodeFreezeLookupTable`, call `decodeData` with `LOOKUP_TABLE_INSTRUCTION_LAYOUTS.FreezeLookupTable` before returning keys. That enforces discriminator `1`.
- In `decodeDeactivateLookupTable`, call `decodeData` with `LOOKUP_TABLE_INSTRUCTION_LAYOUTS.DeactivateLookupTable` so discriminator `3` is required.
- Add regression tests that build a Freeze instruction and assert `decodeDeactivateLookupTable` throws, and the reverse for Deactivate into `decodeFreezeLookupTable`.

## Why

`decodeData` already compares `data.instruction` to the layout index and throws on mismatch. Create and Extend use that path today. Freeze and Deactivate skipped it, which is why cross-decoding worked. Aligning them removes the contradiction where type decoding says Deactivate but the Freeze decoder still returns params.

## How tested

- Reviewed against the existing Freeze/Deactivate builder and decoder tests in `test/program-tests/address-lookup-table.test.ts`.
- Added focused rejection cases that fail under the old key-only checks and pass once `decodeData` validates the discriminator.
- Could not run the full suite in this environment (API-only workflow, no clone). The change mirrors the Create/Extend decoder pattern already covered by the repo tests.

Fixes #3853