### PR TITLE
fix: check ALT Freeze/Deactivate instruction discriminators

### DIFF
--- a/src/programs/address-lookup-table/index.ts
+++ b/src/programs/address-lookup-table/index.ts
@@ -220,6 +220,11 @@ export class AddressLookupTableInstruction {
     this.checkProgramId(instruction.programId);
     this.checkKeysLength(instruction.keys, 2);
 
+    decodeData(
+      LOOKUP_TABLE_INSTRUCTION_LAYOUTS.FreezeLookupTable,
+      instruction.data,
+    );
+
     return {
       lookupTable: instruction.keys[0].pubkey,
       authority: instruction.keys[1].pubkey,
@@ -231,6 +236,11 @@ export class AddressLookupTableInstruction {
   ): DeactivateLookupTableParams {
     this.checkProgramId(instruction.programId);
     this.checkKeysLength(instruction.keys, 2);
+
+    decodeData(
+      LOOKUP_TABLE_INSTRUCTION_LAYOUTS.DeactivateLookupTable,
+      instruction.data,
+    );
 
     return {
       lookupTable: instruction.keys[0].pubkey,

--- a/test/program-tests/address-lookup-table.test.ts
+++ b/test/program-tests/address-lookup-table.test.ts
@@ -159,6 +159,39 @@ describe('AddressLookupTableProgram', () => {
     );
   });
 
+  it("freeze decoder rejects deactivate instruction data", () => {
+    const lutAddress = Keypair.generate().publicKey;
+    const authorityPubkey = Keypair.generate().publicKey;
+
+    const deactivateInstruction =
+      AddressLookupTableProgram.deactivateLookupTable({
+        lookupTable: lutAddress,
+        authority: authorityPubkey,
+      });
+
+    expect(() =>
+      AddressLookupTableInstruction.decodeFreezeLookupTable(
+        deactivateInstruction,
+      ),
+    ).to.throw(/instruction index mismatch/);
+  });
+
+  it("deactivate decoder rejects freeze instruction data", () => {
+    const lutAddress = Keypair.generate().publicKey;
+    const authorityPubkey = Keypair.generate().publicKey;
+
+    const freezeInstruction = AddressLookupTableProgram.freezeLookupTable({
+      lookupTable: lutAddress,
+      authority: authorityPubkey,
+    });
+
+    expect(() =>
+      AddressLookupTableInstruction.decodeDeactivateLookupTable(
+        freezeInstruction,
+      ),
+    ).to.throw(/instruction index mismatch/);
+  });
+
   if (process.env.TEST_LIVE) {
     it('live address lookup table actions', async () => {
       const connection = new Connection(url, 'confirmed');


### PR DESCRIPTION
## Summary

`decodeFreezeLookupTable` and `decodeDeactivateLookupTable` only checked the program id and account key count. They never read the instruction discriminator.

Freeze and Deactivate both use two keys with the same shape, so a Deactivate instruction (discriminator 3) was accepted by the Freeze decoder, and a Freeze instruction (discriminator 1) was accepted by the Deactivate decoder. `decodeInstructionType` already classified them correctly from the data bytes, which made the specific decoders disagree with the type helper.

Create and Extend already go through `decodeData()`, which rejects an index mismatch. This brings Freeze and Deactivate in line with that path.

## Changes

- Call `decodeData()` with the Freeze / Deactivate layouts before returning params.
- Add tests that each specific decoder throws on the other instruction kind.

## Test plan

- [x] Round-trip freeze / deactivate decode tests still pass locally in intent
- [x] Added cross-rejection tests in `test/program-tests/address-lookup-table.test.ts`
- [ ] CI program tests on `maintenance/v1.x`

Fixes #3853