### PR TITLE
refactor: versioned signer

### DIFF
--- a/packages/web3.js/src/transaction/versioned.ts
+++ b/packages/web3.js/src/transaction/versioned.ts
@@ -5,12 +5,16 @@ import {
   getArrayEncoder,
   getBytesDecoder,
   getBytesEncoder,
+  getCompiledTransactionMessageDecoder,
   getShortU16Decoder,
   getShortU16Encoder,
   getStructDecoder,
   getStructEncoder,
-  type MessagePartialSigner,
+  getTransactionLifetimeConstraintFromCompiledTransactionMessage,
+  isSolanaError,
+  SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE,
   type TransactionVersion,
+  type TransactionWithLifetime,
 } from '@solana/kit';
 
 import {
@@ -18,7 +22,9 @@ import {
   signTransactionMessageBytes,
 } from '../kit-adapters/signing';
 import assert from '../utils/assert';
+import type {Signer} from '../keypair';
 import type {PublicKey} from '../publickey';
+import {toPackedUint8Array} from '../utils/typed-array';
 import {VersionedMessage} from '../message/versioned';
 import {
   SIGNATURE_LENGTH_IN_BYTES,
@@ -49,7 +55,17 @@ const VERSIONED_TRANSACTION_DECODER = getStructDecoder([
   ['serializedMessage', getBytesDecoder()],
 ]);
 
+const COMPILED_TRANSACTION_MESSAGE_DECODER =
+  getCompiledTransactionMessageDecoder();
+
 export type {TransactionVersion};
+
+/**
+ * Transaction lifetime information for {@link VersionedTransaction.sign}:
+ * the `lastValidBlockHeight` of the message's blockhash. Durable nonce
+ * lifetimes are detected from the message itself and need no configuration.
+ */
+export type VersionedTransactionSignConfig = {lastValidBlockHeight: bigint};
 
 /**
  * Versioned transaction class
@@ -172,11 +188,15 @@ export class VersionedTransaction {
     );
   }
 
-  async sign(signers: Array<MessagePartialSigner>) {
+  async sign(signers: Array<Signer>, config?: VersionedTransactionSignConfig) {
     const messageData = this.message.serialize();
     const signerPubkeys = this.message.staticAccountKeys.slice(
       0,
       this.message.header.numRequiredSignatures,
+    );
+    const lifetimeConstraint = await getLifetimeConstraint(
+      messageData,
+      config?.lastValidBlockHeight,
     );
     for (const signer of signers) {
       const signerPublicKey = getSignerPublicKey(signer);
@@ -188,13 +208,15 @@ export class VersionedTransaction {
         `Cannot sign with non signer key ${signerPublicKey.toBase58()}`,
       );
 
-      // `MessagePartialSigner` cannot supply transaction lifetime info,
-      // so the optional `signatures` and `lifetimeConstraint` parameters of
-      // `signTransactionMessageBytes` are unused on this path.
       const signature = await signTransactionMessageBytes(
         signer,
         messageData,
         signerPubkeys,
+        signerPubkeys.map((publicKey, index) => ({
+          publicKey,
+          signature: this.signatures[index],
+        })),
+        lifetimeConstraint,
       );
 
       if (signature === undefined) {
@@ -223,4 +245,39 @@ export class VersionedTransaction {
     );
     this.signatures[signerIndex] = signature;
   }
+}
+
+/**
+ * Derive the lifetime constraint of a serialized message. Returns
+ * `undefined` for a durable nonce message whose nonce account is loaded from
+ * an address lookup table, since that address cannot be resolved without
+ * fetching the table; such messages can only be signed by message signers.
+ */
+async function getLifetimeConstraint(
+  messageBytes: Uint8Array,
+  lastValidBlockHeight?: bigint,
+): Promise<TransactionWithLifetime['lifetimeConstraint'] | undefined> {
+  let lifetimeConstraint;
+  try {
+    lifetimeConstraint =
+      await getTransactionLifetimeConstraintFromCompiledTransactionMessage(
+        COMPILED_TRANSACTION_MESSAGE_DECODER.decode(
+          toPackedUint8Array(messageBytes),
+        ),
+      );
+  } catch (e) {
+    if (
+      isSolanaError(
+        e,
+        SOLANA_ERROR__TRANSACTION__NONCE_ACCOUNT_CANNOT_BE_IN_LOOKUP_TABLE,
+      )
+    ) {
+      return undefined;
+    }
+    throw e;
+  }
+  if ('blockhash' in lifetimeConstraint && lastValidBlockHeight != null) {
+    return {...lifetimeConstraint, lastValidBlockHeight};
+  }
+  return lifetimeConstraint;
 }

--- a/packages/web3.js/test/connection.test.ts
+++ b/packages/web3.js/test/connection.test.ts
@@ -6,6 +6,10 @@ import {
   type Blockhash,
 } from '@solana/kit';
 import {getTransferSolInstructionDataEncoder} from '@solana-program/system';
+import {
+  generateKeyPairSigner,
+  type TransactionPartialSigner,
+} from '@solana/signers';
 import {expect, use} from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import {mock, spy, stub, useFakeTimers, SinonFakeTimers} from 'sinon';
@@ -7703,6 +7707,55 @@ describe('Connection', function () {
 
       await versionedTx.sign([payer]);
       await connection.sendTransaction(versionedTx);
+    });
+
+    it('sendTransaction with a v1 transaction signed by a Kit transaction partial signer', async () => {
+      const connection = new Connection(url, 'confirmed');
+      const payer = await generateKeyPairSigner();
+      const payerPublicKey = new PublicKey(payer.address);
+      const transactionOnlySigner = {
+        address: payer.address,
+        signTransactions: payer.signTransactions,
+      } satisfies TransactionPartialSigner;
+
+      await helpers.airdrop({
+        connection,
+        address: payerPublicKey,
+        amount: LAMPORTS_PER_SOL,
+      });
+
+      const {blockhash, lastValidBlockHeight} = await helpers.latestBlockhash({
+        connection,
+      });
+
+      const recipient = await Keypair.generate();
+      const transferLamports = LAMPORTS_PER_SOL / 10;
+      const versionedTx = new VersionedTransaction(
+        new TransactionMessage({
+          payerKey: payerPublicKey,
+          recentBlockhash: blockhash,
+          instructions: [
+            SystemProgram.transfer({
+              fromPubkey: payerPublicKey,
+              toPubkey: recipient.publicKey,
+              lamports: transferLamports,
+            }),
+          ],
+        }).compileToV1Message({
+          computeUnitLimit: 200_000,
+          loadedAccountsDataSizeLimit: 1_000_000,
+        }),
+      );
+      await versionedTx.sign([transactionOnlySigner], {lastValidBlockHeight});
+
+      const signature = await connection.sendTransaction(versionedTx);
+      await connection.confirmTransaction(
+        {signature, blockhash, lastValidBlockHeight},
+        'confirmed',
+      );
+      expect(await connection.getBalance(recipient.publicKey)).to.eq(
+        BigInt(transferLamports),
+      );
     });
 
     it('simulateTransaction', async () => {

--- a/packages/web3.js/test/transaction.test.ts
+++ b/packages/web3.js/test/transaction.test.ts
@@ -1597,6 +1597,175 @@ describe('VersionedTransaction', () => {
     expect(Buffer.from(versionedTx.signatures[0])).to.not.eql(Buffer.alloc(64));
   });
 
+  describe('sign with kit transaction partial signers', () => {
+    const makeTransactionOnlySigner = (
+      keyPairSigner: TransactionPartialSigner,
+    ) => {
+      let signedTransaction: {
+        lifetimeConstraint?: unknown;
+        signatures?: unknown;
+      } = {};
+      const signer = {
+        address: keyPairSigner.address,
+        signTransactions: async (
+          transactions: Parameters<
+            TransactionPartialSigner['signTransactions']
+          >[0],
+        ) => {
+          signedTransaction = transactions[0];
+          return await keyPairSigner.signTransactions(transactions);
+        },
+      } satisfies TransactionPartialSigner;
+      return {
+        getLifetimeConstraint: () => signedTransaction.lifetimeConstraint,
+        getSignatures: () => signedTransaction.signatures,
+        signer,
+      };
+    };
+
+    it('forwards lastValidBlockHeight in the blockhash lifetime', async () => {
+      const keyPairSigner = await generateKeyPairSigner();
+      const recentBlockhash = await generateBlockhash();
+      const {signer, getLifetimeConstraint} =
+        makeTransactionOnlySigner(keyPairSigner);
+      const message = new TransactionMessage({
+        payerKey: new PublicKey(keyPairSigner.address),
+        recentBlockhash,
+        instructions: [],
+      }).compileToV1Message();
+
+      const transaction = new VersionedTransaction(message);
+      await transaction.sign([signer], {lastValidBlockHeight: 9999n});
+
+      expect(getLifetimeConstraint()).to.deep.equal({
+        blockhash: recentBlockhash,
+        lastValidBlockHeight: 9999n,
+      });
+      expect(Buffer.from(transaction.signatures[0])).to.not.eql(
+        Buffer.alloc(64),
+      );
+    });
+
+    it('defaults to the maximum lastValidBlockHeight when none is provided', async () => {
+      const keyPairSigner = await generateKeyPairSigner();
+      const recentBlockhash = await generateBlockhash();
+      const {signer, getLifetimeConstraint} =
+        makeTransactionOnlySigner(keyPairSigner);
+      const message = new TransactionMessage({
+        payerKey: new PublicKey(keyPairSigner.address),
+        recentBlockhash,
+        instructions: [],
+      }).compileToV0Message();
+
+      const transaction = new VersionedTransaction(message);
+      await transaction.sign([signer]);
+
+      expect(getLifetimeConstraint()).to.deep.equal({
+        blockhash: recentBlockhash,
+        lastValidBlockHeight: 0xffffffffffffffffn,
+      });
+    });
+
+    it('passes a nonce lifetime when the first instruction advances a durable nonce', async () => {
+      const keyPairSigner = await generateKeyPairSigner();
+      const nonceAccount = await generateKeypair();
+      const nonce = await generateBlockhash();
+      const {signer, getLifetimeConstraint} =
+        makeTransactionOnlySigner(keyPairSigner);
+      const message = new TransactionMessage({
+        payerKey: new PublicKey(keyPairSigner.address),
+        recentBlockhash: nonce,
+        instructions: [
+          SystemProgram.nonceAdvance({
+            noncePubkey: nonceAccount.publicKey,
+            authorizedPubkey: new PublicKey(keyPairSigner.address),
+          }),
+        ],
+      }).compileToV1Message();
+
+      const transaction = new VersionedTransaction(message);
+      await transaction.sign([signer], {lastValidBlockHeight: 9999n});
+
+      expect(getLifetimeConstraint()).to.deep.equal({
+        nonce,
+        nonceAccountAddress: nonceAccount.address,
+      });
+    });
+
+    it('passes previously added signatures through to the signer', async () => {
+      const payer = await generateKeyPairSigner();
+      const coSigner = await generateKeypair();
+      const programId = (await generateKeypair()).publicKey;
+      const recentBlockhash = await generateBlockhash();
+      const coSignerSignature = new Uint8Array(64).fill(1);
+      const {signer, getSignatures} = makeTransactionOnlySigner(payer);
+      const message = new TransactionMessage({
+        payerKey: new PublicKey(payer.address),
+        recentBlockhash,
+        instructions: [
+          new TransactionInstruction({
+            keys: [
+              {pubkey: coSigner.publicKey, isSigner: true, isWritable: false},
+            ],
+            programId,
+          }),
+        ],
+      }).compileToV0Message();
+
+      const transaction = new VersionedTransaction(message);
+      transaction.addSignature(coSigner.publicKey, coSignerSignature);
+      await transaction.sign([signer]);
+
+      expect(getSignatures()).to.deep.equal({
+        [payer.address]: null,
+        [coSigner.address]: coSignerSignature,
+      });
+      expect(Buffer.from(transaction.signatures[0])).to.not.eql(
+        Buffer.alloc(64),
+      );
+      expect(transaction.signatures[1]).to.eql(coSignerSignature);
+    });
+
+    it('signs with a mix of transaction-only and message signers', async () => {
+      const payer = await generateKeyPairSigner();
+      const coSigner = await generateKeyPairSigner();
+      const programId = (await generateKeypair()).publicKey;
+      const recentBlockhash = await generateBlockhash();
+      const transactionOnlySigner = {
+        address: coSigner.address,
+        signTransactions: coSigner.signTransactions,
+      } satisfies TransactionPartialSigner;
+      const messageOnlySigner = {
+        address: payer.address,
+        signMessages: payer.signMessages,
+      } satisfies MessagePartialSigner;
+      const message = new TransactionMessage({
+        payerKey: new PublicKey(payer.address),
+        recentBlockhash,
+        instructions: [
+          new TransactionInstruction({
+            keys: [
+              {
+                pubkey: new PublicKey(coSigner.address),
+                isSigner: true,
+                isWritable: false,
+              },
+            ],
+            programId,
+          }),
+        ],
+      }).compileToV0Message();
+
+      const transaction = new VersionedTransaction(message);
+      await transaction.sign([messageOnlySigner, transactionOnlySigner]);
+
+      expect(transaction.signatures).to.have.length(2);
+      for (const signature of transaction.signatures) {
+        expect(Buffer.from(signature)).to.not.eql(Buffer.alloc(64));
+      }
+    });
+  });
+
   describe('addSignature', () => {
     let signer1: Keypair;
     let signer2: Keypair;


### PR DESCRIPTION
Modifies versioned transaction `sign` method to support the full `Signer` interface:


### Before

```ts
async sign(signers: Array<MessagePartialSigner>)
```

### After

 ```ts
async sign(signers: Array<Signer>, config?: VersionedTransactionSignConfig)
```

Optional config includes `lastValidBlockHeight` and leverage `getTransactionLifetimeConstraintFromCompiledTransactionMessage` from Kit to use nonce values or fallback blockheight when appropriate. 

### Alternative

We could drop the `getLifetimeConstraint` wrapper around `getTransactionLifetimeConstraintFromCompiledTransactionMessage` but would need to drop `MessagePartialSigner` support here. IMO this seems appropriate for this use case and could be handled simply w/ a `assertIsTransactionPartialSigner` call or by throwing in `case 'kit-msg'`.  This would allow `Signer` stay unchagned so we could use `Signer` in future things like OCMS.