### PR TITLE
chore: update useDisconnectButton

### DIFF
--- a/packages/wallet-adapter/RELEASE_NOTES.md
+++ b/packages/wallet-adapter/RELEASE_NOTES.md
@@ -37,7 +37,7 @@ Changing `chain`, `filter` or the storage options rebuilds the client and discon
 Behavior:
 
 - `select(name)` records the choice and never throws. It no longer connects; `connect()` does, and rejects with `WalletNotSelectedError` or `WalletNotReadyError`. The packaged modal selects and connects in one click.
-- `wallet` and `publicKey` describe the live connection; `selectedWallet` is the picker's choice. If a switch is rejected, the previous connection stays.
+- `publicKey` describes the live connection; `selectedWallet` is the picker's choice, and `wallet` is the connected wallet or, while disconnected, the selection. If a switch is rejected, the previous connection stays. The disconnect button and `useWalletDisconnectButton` are enabled only while connected.
 - `signTransaction`, `signAllTransactions`, `signMessage` and `signOffchainMessage` are `undefined` when the account can't do them; `signIn` when the selected wallet can't. Sign-in hands back the Wallet Standard output for you to verify.
 - `supportedTransactionVersions` moves from the adapter to the snapshot and describes the connected account rather than the wallet. It is `null` while disconnected; test membership for the version you intend to send, for example `supportedTransactionVersions?.has(1)`.
 - Everything returns a promise. Hooks throw `WalletConfigError` when their provider is missing.

--- a/packages/wallet-adapter/src/__tests__/WalletMultiButton-test.tsx
+++ b/packages/wallet-adapter/src/__tests__/WalletMultiButton-test.tsx
@@ -143,6 +143,7 @@ it('keeps custom labels, cancellable clicks and headless operation failures', as
     onSelectWallet: result.current.wallet.select,
   });
   act(() => result.current.wallet.select(wallet.name));
+  expect(result.current.disconnect.buttonState).toBe('no-wallet');
   fireEvent.click(screen.getByRole('button', {name: 'Custom authorization'}));
   expect(screen.getByText('Authorize')).toBeDefined();
   expect(onClick).toHaveBeenCalledTimes(1);
@@ -159,6 +160,7 @@ it('keeps custom labels, cancellable clicks and headless operation failures', as
     await result.current.multi.onConnect!();
   });
   expect(result.current.connect.buttonState).toBe('connected');
+  expect(result.current.disconnect.buttonState).toBe('has-wallet');
   expect(result.current.multi.publicKey).toEqual(
     result.current.wallet.publicKey,
   );

--- a/packages/wallet-adapter/src/ui/useWalletButton.ts
+++ b/packages/wallet-adapter/src/ui/useWalletButton.ts
@@ -25,10 +25,10 @@ export function useWalletConnectButton() {
 
 /** Disconnection state and the original operation promise for a custom control. */
 export function useWalletDisconnectButton() {
-  const {disconnect, disconnecting, wallet} = useWallet();
+  const {connected, disconnect, disconnecting, wallet} = useWallet();
   const buttonState = disconnecting
     ? 'disconnecting'
-    : wallet
+    : connected
       ? 'has-wallet'
       : 'no-wallet';
   return {


### PR DESCRIPTION
rn a selected wallet enables the disconnect button, even if it is not connected.

this PR chagnes it so disconnect button is only active when a wallet is connected.
