### PR TITLE
fix(web3.js): reconcile signature status before reporting blockheight expiry (SOLA8-99)

### DIFF
--- a/packages/web3.js/src/connection.ts
+++ b/packages/web3.js/src/connection.ts
@@ -3809,7 +3809,23 @@ export class Connection {
       if (outcome.__type === TransactionStatus.PROCESSED) {
         result = outcome.response;
       } else {
-        throw new TransactionExpiredBlockheightExceededError(signature);
+        // Double check that the transaction is indeed unconfirmed.
+        const signatureStatus = await this.getSignatureStatus(signature);
+        if (
+          signatureStatus?.value &&
+          confirmationStatusSatisfiesCommitment(
+            commitment,
+            signatureStatus.value.confirmationStatus,
+            false,
+          )
+        ) {
+          result = {
+            context: {slot: signatureStatus.context.slot},
+            value: {err: signatureStatus.value.err},
+          };
+        } else {
+          throw new TransactionExpiredBlockheightExceededError(signature);
+        }
       }
     } finally {
       done = true;

--- a/packages/web3.js/src/connection.ts
+++ b/packages/web3.js/src/connection.ts
@@ -3810,7 +3810,10 @@ export class Connection {
         result = outcome.response;
       } else {
         // Double check that the transaction is indeed unconfirmed.
-        const signatureStatus = await this.getSignatureStatus(signature);
+        const signatureStatus = await Promise.race([
+          this.getSignatureStatus(signature),
+          cancellationPromise,
+        ]);
         if (
           signatureStatus?.value &&
           confirmationStatusSatisfiesCommitment(

--- a/packages/web3.js/test/connection.test.ts
+++ b/packages/web3.js/test/connection.test.ts
@@ -2875,6 +2875,77 @@ describe('Connection', function () {
           expect(getBlockHeightCallCount).to.equal(3);
         });
 
+        it('confirms the transaction when the block height is exceeded but a final status check shows it landed', async () => {
+          const mockSignature =
+            '4oCEqwGrMdBeMxpzuWiukCYqSfV4DsSKXSiVVCh1iJ6pS772X7y219JZP3mgqBz5PhsvprpKyhzChjYc3VSBQXzG';
+          const lastValidBlockHeight = 3;
+
+          await teardownSubscriptions(connection);
+          const fetchBlockHeights = [
+            lastValidBlockHeight,
+            lastValidBlockHeight + 1,
+          ];
+          let getSignatureStatusesCallCount = 0;
+          const fetch = stub().callsFake((_url, requestInfo) => {
+            const {method} = JSON.parse(requestInfo.body);
+            if (method === 'getBlockHeight') {
+              const blockHeight = fetchBlockHeights.shift();
+              expect(blockHeight).to.not.be.undefined;
+              return new Response(
+                JSON.stringify({jsonrpc: '2.0', id: '', result: blockHeight}),
+                {
+                  headers: {'content-type': 'application/json'},
+                  status: 200,
+                },
+              );
+            }
+
+            expect(method).to.equal('getSignatureStatuses');
+            getSignatureStatusesCallCount += 1;
+            const value =
+              getSignatureStatusesCallCount > 1
+                ? [
+                    {
+                      confirmationStatus: 'confirmed',
+                      confirmations: 1,
+                      err: null,
+                      slot: 3,
+                    },
+                  ]
+                : [null];
+            return new Response(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: '',
+                result: {context: {slot: 3}, value},
+              }),
+              {
+                headers: {'content-type': 'application/json'},
+                status: 200,
+              },
+            );
+          });
+          connection = stubSubscriptions(url, {fetch});
+          await mockRpcMessage({
+            method: 'signatureSubscribe',
+            params: [mockSignature, {commitment: 'confirmed'}],
+            result: new Promise(() => {}), // Never resolve this = never get a response.
+          });
+
+          const confirmationPromise = connection.confirmTransaction({
+            signature: mockSignature,
+            blockhash: SAMPLE_BLOCKHASH,
+            lastValidBlockHeight,
+          });
+          await clock.tickAsync(0);
+          await clock.tickAsync(1000);
+          await clock.tickAsync(1000);
+          const result = await confirmationPromise;
+          expect(result.value.err).to.be.null;
+          expect(result.context.slot).to.equal(3n);
+          expect(getSignatureStatusesCallCount).to.equal(2);
+        });
+
         it('when the `getBlockHeight` method throws an error it does not timeout but rather keeps waiting for a confirmation', async () => {
           const mockSignature =
             'LPJ18iiyfz3G1LpNNbcBnBtaS4dVBdPHKrnELqikjER2DcvB4iyTgz43nKQJH3JQAJHuZdM1xVh5Cnc5Hc7LrqC';

--- a/packages/web3.js/test/connection.test.ts
+++ b/packages/web3.js/test/connection.test.ts
@@ -2946,6 +2946,68 @@ describe('Connection', function () {
           expect(getSignatureStatusesCallCount).to.equal(2);
         });
 
+        it('rejects with the abort reason when the caller aborts during the final status check after the block height is exceeded', async () => {
+          const mockSignature =
+            '4oCEqwGrMdBeMxpzuWiukCYqSfV4DsSKXSiVVCh1iJ6pS772X7y219JZP3mgqBz5PhsvprpKyhzChjYc3VSBQXzG';
+          const lastValidBlockHeight = 3;
+
+          await teardownSubscriptions(connection);
+          let getSignatureStatusesCallCount = 0;
+          const fetch = stub().callsFake((_url, requestInfo) => {
+            const {method} = JSON.parse(requestInfo.body);
+            if (method === 'getBlockHeight') {
+              return new Response(
+                JSON.stringify({
+                  jsonrpc: '2.0',
+                  id: '',
+                  result: lastValidBlockHeight + 1,
+                }),
+                {
+                  headers: {'content-type': 'application/json'},
+                  status: 200,
+                },
+              );
+            }
+
+            expect(method).to.equal('getSignatureStatuses');
+            getSignatureStatusesCallCount += 1;
+            if (getSignatureStatusesCallCount === 1) {
+              return new Response(
+                JSON.stringify({
+                  jsonrpc: '2.0',
+                  id: '',
+                  result: {context: {slot: 3}, value: [null]},
+                }),
+                {
+                  headers: {'content-type': 'application/json'},
+                  status: 200,
+                },
+              );
+            }
+            return new Promise(() => {}); // The final status check stalls forever.
+          });
+          connection = stubSubscriptions(url, {fetch});
+          await mockRpcMessage({
+            method: 'signatureSubscribe',
+            params: [mockSignature, {commitment: 'confirmed'}],
+            result: new Promise(() => {}), // Never resolve this = never get a response.
+          });
+
+          const abortController = new AbortController();
+          const confirmationPromise = connection.confirmTransaction({
+            abortSignal: abortController.signal,
+            signature: mockSignature,
+            blockhash: SAMPLE_BLOCKHASH,
+            lastValidBlockHeight,
+          });
+          await clock.tickAsync(0);
+          expect(getSignatureStatusesCallCount).to.equal(2);
+          abortController.abort(new Error('aborted by caller'));
+          await expect(confirmationPromise).to.be.rejectedWith(
+            'aborted by caller',
+          );
+        });
+
         it('when the `getBlockHeight` method throws an error it does not timeout but rather keeps waiting for a confirmation', async () => {
           const mockSignature =
             'LPJ18iiyfz3G1LpNNbcBnBtaS4dVBdPHKrnELqikjER2DcvB4iyTgz43nKQJH3JQAJHuZdM1xVh5Cnc5Hc7LrqC';


### PR DESCRIPTION
Match how we handle nonce confirmation and do a final `getSignatureStatus` check after blockheight expiration for late landing transactions.

Closes APE-254