### PR TITLE
fix(web3.js): copy message header at construction so caller mutation cannot change signed bytes (SOLA8-46)

### DIFF
--- a/packages/web3.js/src/message/legacy.ts
+++ b/packages/web3.js/src/message/legacy.ts
@@ -72,7 +72,7 @@ export type CompileLegacyArgs = {
  * List of instructions to be processed atomically
  */
 export class Message {
-  header: MessageHeader;
+  readonly header: Readonly<MessageHeader>;
   accountKeys: PublicKey[];
   recentBlockhash: Blockhash;
   instructions: CompiledInstruction[];
@@ -83,7 +83,7 @@ export class Message {
   >();
 
   constructor(args: MessageArgs) {
-    this.header = args.header;
+    this.header = Object.freeze({...args.header});
     this.accountKeys = args.accountKeys.map(account => new PublicKey(account));
     this.recentBlockhash = args.recentBlockhash;
     this.instructions = args.instructions;

--- a/packages/web3.js/src/message/v0.ts
+++ b/packages/web3.js/src/message/v0.ts
@@ -62,14 +62,14 @@ export type GetAccountKeysArgs =
     };
 
 export class MessageV0 {
-  header: MessageHeader;
+  readonly header: Readonly<MessageHeader>;
   staticAccountKeys: Array<PublicKey>;
   recentBlockhash: Blockhash;
   compiledInstructions: Array<MessageCompiledInstruction>;
   addressTableLookups: Array<MessageAddressTableLookup>;
 
   constructor(args: MessageV0Args) {
-    this.header = args.header;
+    this.header = Object.freeze({...args.header});
     this.staticAccountKeys = args.staticAccountKeys;
     this.recentBlockhash = args.recentBlockhash;
     this.compiledInstructions = args.compiledInstructions;

--- a/packages/web3.js/src/message/v1.ts
+++ b/packages/web3.js/src/message/v1.ts
@@ -153,7 +153,7 @@ export type CompileV1Args = {
  * `maxSupportedTransactionVersion: 1` to `getTransaction`/`getBlock`.
  */
 export class MessageV1 {
-  header: MessageHeader;
+  readonly header: Readonly<MessageHeader>;
   staticAccountKeys: Array<PublicKey>;
   recentBlockhash: Blockhash;
   compiledInstructions: Array<MessageCompiledInstruction>;
@@ -161,7 +161,7 @@ export class MessageV1 {
   transactionConfig?: V1TransactionConfig;
 
   constructor(args: MessageV1Args) {
-    this.header = args.header;
+    this.header = Object.freeze({...args.header});
     this.staticAccountKeys = args.staticAccountKeys;
     this.recentBlockhash = args.recentBlockhash;
     this.compiledInstructions = args.compiledInstructions;

--- a/packages/web3.js/test/message-tests/legacy.test.ts
+++ b/packages/web3.js/test/message-tests/legacy.test.ts
@@ -253,6 +253,25 @@ describe('Message', () => {
     expect(Message.from(Array.from(serialized)).serialize()).to.eql(serialized);
   });
 
+  it('copies the header so later mutation of the argument does not change the message', () => {
+    const header = {
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 2,
+    };
+    const message = new Message({
+      header,
+      recentBlockhash: TEST_RECENT_BLOCKHASH,
+      accountKeys: createTestKeys(3),
+      instructions: [],
+    });
+    expect(message.isAccountWritable(1)).to.be.false;
+    header.numReadonlyUnsignedAccounts = 1;
+    expect(message.header.numReadonlyUnsignedAccounts).to.equal(2);
+    expect(message.isAccountWritable(1)).to.be.false;
+    expect(Object.isFrozen(message.header)).to.be.true;
+  });
+
   it('isAccountWritable', () => {
     const accountKeys = [
       getUniqueAddress(),

--- a/packages/web3.js/test/message-tests/legacy.test.ts
+++ b/packages/web3.js/test/message-tests/legacy.test.ts
@@ -265,10 +265,18 @@ describe('Message', () => {
       accountKeys: createTestKeys(3),
       instructions: [],
     });
+    const serializedBefore = message.serialize();
     expect(message.isAccountWritable(1)).to.be.false;
+    header.numRequiredSignatures = 2;
+    header.numReadonlySignedAccounts = 1;
     header.numReadonlyUnsignedAccounts = 1;
-    expect(message.header.numReadonlyUnsignedAccounts).to.equal(2);
+    expect(message.header).to.eql({
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 2,
+    });
     expect(message.isAccountWritable(1)).to.be.false;
+    expect(message.serialize()).to.eql(serializedBefore);
     expect(Object.isFrozen(message.header)).to.be.true;
   });
 

--- a/packages/web3.js/test/message-tests/v0.test.ts
+++ b/packages/web3.js/test/message-tests/v0.test.ts
@@ -407,6 +407,26 @@ describe('MessageV0', () => {
     );
   });
 
+  it('copies the header so later mutation of the argument does not change the message', () => {
+    const header = {
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 2,
+    };
+    const message = new MessageV0({
+      header,
+      recentBlockhash: TEST_RECENT_BLOCKHASH,
+      staticAccountKeys: createTestKeys(3),
+      compiledInstructions: [],
+      addressTableLookups: [],
+    });
+    expect(message.isAccountWritable(1)).to.be.false;
+    header.numReadonlyUnsignedAccounts = 1;
+    expect(message.header.numReadonlyUnsignedAccounts).to.equal(2);
+    expect(message.isAccountWritable(1)).to.be.false;
+    expect(Object.isFrozen(message.header)).to.be.true;
+  });
+
   it('isAccountWritable', () => {
     const staticAccountKeys = [
       getUniqueAddress(),

--- a/packages/web3.js/test/message-tests/v0.test.ts
+++ b/packages/web3.js/test/message-tests/v0.test.ts
@@ -420,10 +420,18 @@ describe('MessageV0', () => {
       compiledInstructions: [],
       addressTableLookups: [],
     });
+    const serializedBefore = message.serialize();
     expect(message.isAccountWritable(1)).to.be.false;
+    header.numRequiredSignatures = 2;
+    header.numReadonlySignedAccounts = 1;
     header.numReadonlyUnsignedAccounts = 1;
-    expect(message.header.numReadonlyUnsignedAccounts).to.equal(2);
+    expect(message.header).to.eql({
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 2,
+    });
     expect(message.isAccountWritable(1)).to.be.false;
+    expect(message.serialize()).to.eql(serializedBefore);
     expect(Object.isFrozen(message.header)).to.be.true;
   });
 

--- a/packages/web3.js/test/message-tests/v1.test.ts
+++ b/packages/web3.js/test/message-tests/v1.test.ts
@@ -298,6 +298,25 @@ describe('MessageV1', () => {
     );
   });
 
+  it('copies the header so later mutation of the argument does not change the message', () => {
+    const header = {
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 2,
+    };
+    const message = new MessageV1({
+      header,
+      recentBlockhash: TEST_RECENT_BLOCKHASH,
+      staticAccountKeys: createTestKeys(3),
+      compiledInstructions: [],
+    });
+    expect(message.isAccountWritable(1)).to.be.false;
+    header.numReadonlyUnsignedAccounts = 1;
+    expect(message.header.numReadonlyUnsignedAccounts).to.equal(2);
+    expect(message.isAccountWritable(1)).to.be.false;
+    expect(Object.isFrozen(message.header)).to.be.true;
+  });
+
   it('isAccountWritable', () => {
     const staticAccountKeys = [
       getUniqueAddress(),

--- a/packages/web3.js/test/message-tests/v1.test.ts
+++ b/packages/web3.js/test/message-tests/v1.test.ts
@@ -310,10 +310,18 @@ describe('MessageV1', () => {
       staticAccountKeys: createTestKeys(3),
       compiledInstructions: [],
     });
+    const serializedBefore = message.serialize();
     expect(message.isAccountWritable(1)).to.be.false;
+    header.numRequiredSignatures = 2;
+    header.numReadonlySignedAccounts = 1;
     header.numReadonlyUnsignedAccounts = 1;
-    expect(message.header.numReadonlyUnsignedAccounts).to.equal(2);
+    expect(message.header).to.eql({
+      numRequiredSignatures: 1,
+      numReadonlySignedAccounts: 0,
+      numReadonlyUnsignedAccounts: 2,
+    });
     expect(message.isAccountWritable(1)).to.be.false;
+    expect(message.serialize()).to.eql(serializedBefore);
     expect(Object.isFrozen(message.header)).to.be.true;
   });
 


### PR DESCRIPTION
Copy & freeze message header to avoid mutation.

Closes APE-258