### PR TITLE
fix(web3.js): reject instructions carrying both Kit and legacy fields (SOLA8-86)

### DIFF
--- a/packages/web3.js/src/kit-adapters/instruction-guard.ts
+++ b/packages/web3.js/src/kit-adapters/instruction-guard.ts
@@ -4,15 +4,32 @@ import {
   type Instruction as KitInstruction,
 } from '@solana/kit';
 
+/**
+ * Determines whether a value has the shape of a Kit `Instruction`, so that
+ * callers accepting either instruction format can route appropriately.
+ *
+ * @throws If the value carries both Kit (`programAddress`/`accounts`) and
+ * legacy (`programId`/`keys`) fields.
+ */
 export function isKitInstruction(value: unknown): value is KitInstruction {
   if (typeof value !== 'object' || value === null) {
     return false;
   }
 
-  const {accounts, data, programAddress} = value as Record<string, unknown>;
+  const {accounts, data, keys, programAddress, programId} = value as Record<
+    string,
+    unknown
+  >;
 
   if (typeof programAddress !== 'string' || !isAddress(programAddress)) {
     return false;
+  }
+
+  if (programId !== undefined || keys !== undefined) {
+    throw new Error(
+      'Ambiguous instruction: an object must not carry both Kit ' +
+        '(`programAddress`/`accounts`) and legacy (`programId`/`keys`) fields.',
+    );
   }
 
   if (accounts !== undefined) {

--- a/packages/web3.js/src/kit-adapters/instruction-guard.ts
+++ b/packages/web3.js/src/kit-adapters/instruction-guard.ts
@@ -21,15 +21,18 @@ export function isKitInstruction(value: unknown): value is KitInstruction {
     unknown
   >;
 
-  if (typeof programAddress !== 'string' || !isAddress(programAddress)) {
-    return false;
-  }
-
-  if (programId !== undefined || keys !== undefined) {
+  if (
+    (programAddress !== undefined || accounts !== undefined) &&
+    (programId !== undefined || keys !== undefined)
+  ) {
     throw new Error(
       'Ambiguous instruction: an object must not carry both Kit ' +
         '(`programAddress`/`accounts`) and legacy (`programId`/`keys`) fields.',
     );
+  }
+
+  if (typeof programAddress !== 'string' || !isAddress(programAddress)) {
+    return false;
   }
 
   if (accounts !== undefined) {

--- a/packages/web3.js/test/kit-adapter-tests/instruction.test.ts
+++ b/packages/web3.js/test/kit-adapter-tests/instruction.test.ts
@@ -1,8 +1,16 @@
-import {AccountRole, address, createNoopSigner} from '@solana/kit';
+import {AccountRole, address, blockhash, createNoopSigner} from '@solana/kit';
 import {getTransferSolInstruction} from '@solana-program/system';
 import {expect} from 'chai';
 
-import {PublicKey, Keypair, SystemInstruction} from '../../src';
+import {
+  Message,
+  MessageV0,
+  PublicKey,
+  Keypair,
+  SystemInstruction,
+  SystemProgram,
+  TransactionMessage,
+} from '../../src';
 import {
   fromKitInstruction,
   toKitInstruction,
@@ -286,6 +294,23 @@ describe('isKitInstruction', () => {
     ).to.be.true;
   });
 
+  it('throws when an object carries both Kit and legacy instruction fields', () => {
+    const programId = new PublicKey('11111111111111111111111111111111');
+    expect(() =>
+      isKitInstruction({
+        programAddress: programId.toBase58(),
+        programId,
+        keys: [],
+      }),
+    ).to.throw(/Ambiguous instruction/);
+    expect(() =>
+      isKitInstruction({
+        programAddress: programId.toBase58(),
+        keys: [],
+      }),
+    ).to.throw(/Ambiguous instruction/);
+  });
+
   it('returns false when programAddress is not a valid address', () => {
     expect(
       isKitInstruction({
@@ -298,8 +323,7 @@ describe('isKitInstruction', () => {
     expect(
       isKitInstruction({
         programAddress: address('11111111111111111111111111111111'),
-        programId: PublicKey.default,
-        keys: [],
+        label: 'transfer',
       }),
     ).to.be.true;
   });
@@ -449,5 +473,85 @@ describe('Transaction.add() with Kit instructions', () => {
     expect(transaction.instructions[1].data).to.deep.equal(
       new Uint8Array([20]),
     );
+  });
+});
+
+describe('ambiguous dual-shaped instructions', () => {
+  const payer = new PublicKey(new Uint8Array(32).fill(7));
+  const safeDestination = new PublicKey(new Uint8Array(32).fill(8));
+  const attackerDestination = new PublicKey(new Uint8Array(32).fill(9));
+  const recentBlockhash = blockhash('11111111111111111111111111111111');
+
+  function dualInstruction() {
+    const legacy = SystemProgram.transfer({
+      fromPubkey: payer,
+      toPubkey: safeDestination,
+      lamports: 42n,
+    });
+    return {
+      programId: legacy.programId,
+      keys: legacy.keys,
+      data: legacy.data,
+      programAddress: SystemProgram.programId.toBase58(),
+      accounts: [
+        {address: payer.toBase58(), role: AccountRole.WRITABLE_SIGNER},
+        {address: attackerDestination.toBase58(), role: AccountRole.WRITABLE},
+      ],
+    };
+  }
+
+  it('Transaction.add() rejects an object carrying both Kit and legacy fields', () => {
+    expect(() =>
+      new Transaction().add(dualInstruction() as unknown as TransactionInstruction),
+    ).to.throw(/Ambiguous instruction/);
+  });
+
+  it('TransactionMessage rejects an object carrying both Kit and legacy fields', () => {
+    expect(
+      () =>
+        new TransactionMessage({
+          payerKey: payer,
+          recentBlockhash,
+          instructions: [dualInstruction() as unknown as TransactionInstruction],
+        }),
+    ).to.throw(/Ambiguous instruction/);
+  });
+
+  it('Message.compile() rejects an object carrying both Kit and legacy fields', () => {
+    expect(() =>
+      Message.compile({
+        payerKey: payer,
+        recentBlockhash,
+        instructions: [dualInstruction() as unknown as TransactionInstruction],
+      }),
+    ).to.throw(/Ambiguous instruction/);
+  });
+
+  it('MessageV0.compile() rejects an object carrying both Kit and legacy fields', () => {
+    expect(() =>
+      MessageV0.compile({
+        payerKey: payer,
+        recentBlockhash,
+        instructions: [dualInstruction() as unknown as TransactionInstruction],
+      }),
+    ).to.throw(/Ambiguous instruction/);
+  });
+
+  it('still accepts a legacy instruction and a Kit instruction for the same transfer', () => {
+    const {programId, keys, data, programAddress, accounts} =
+      dualInstruction();
+
+    const transaction = new Transaction().add(
+      new TransactionInstruction({programId, keys, data}),
+      {programAddress, accounts, data},
+    );
+
+    expect(transaction.instructions).to.have.length(2);
+    expect(
+      SystemInstruction.decodeTransfer(transaction.instructions[0]).toPubkey,
+    ).to.deep.equal(safeDestination);
+    expect(
+      SystemInstruction.decodeTransfer(transaction.instructions[1]).toPubkey,
+    ).to.deep.equal(attackerDestination);
   });
 });

--- a/packages/web3.js/test/kit-adapter-tests/instruction.test.ts
+++ b/packages/web3.js/test/kit-adapter-tests/instruction.test.ts
@@ -5,6 +5,7 @@ import {expect} from 'chai';
 import {
   Message,
   MessageV0,
+  MessageV1,
   PublicKey,
   Keypair,
   SystemInstruction,
@@ -309,6 +310,20 @@ describe('isKitInstruction', () => {
         keys: [],
       }),
     ).to.throw(/Ambiguous instruction/);
+    expect(() =>
+      isKitInstruction({
+        programAddress: 'not-an-address',
+        programId,
+        keys: [],
+      }),
+    ).to.throw(/Ambiguous instruction/);
+    expect(() =>
+      isKitInstruction({
+        accounts: [],
+        programId,
+        keys: [],
+      }),
+    ).to.throw(/Ambiguous instruction/);
   });
 
   it('returns false when programAddress is not a valid address', () => {
@@ -502,7 +517,9 @@ describe('ambiguous dual-shaped instructions', () => {
 
   it('Transaction.add() rejects an object carrying both Kit and legacy fields', () => {
     expect(() =>
-      new Transaction().add(dualInstruction() as unknown as TransactionInstruction),
+      new Transaction().add(
+        dualInstruction() as unknown as TransactionInstruction,
+      ),
     ).to.throw(/Ambiguous instruction/);
   });
 
@@ -512,7 +529,9 @@ describe('ambiguous dual-shaped instructions', () => {
         new TransactionMessage({
           payerKey: payer,
           recentBlockhash,
-          instructions: [dualInstruction() as unknown as TransactionInstruction],
+          instructions: [
+            dualInstruction() as unknown as TransactionInstruction,
+          ],
         }),
     ).to.throw(/Ambiguous instruction/);
   });
@@ -537,9 +556,18 @@ describe('ambiguous dual-shaped instructions', () => {
     ).to.throw(/Ambiguous instruction/);
   });
 
+  it('MessageV1.compile() rejects an object carrying both Kit and legacy fields', () => {
+    expect(() =>
+      MessageV1.compile({
+        payerKey: payer,
+        recentBlockhash,
+        instructions: [dualInstruction() as unknown as TransactionInstruction],
+      }),
+    ).to.throw(/Ambiguous instruction/);
+  });
+
   it('still accepts a legacy instruction and a Kit instruction for the same transfer', () => {
-    const {programId, keys, data, programAddress, accounts} =
-      dualInstruction();
+    const {programId, keys, data, programAddress, accounts} = dualInstruction();
 
     const transaction = new Transaction().add(
       new TransactionInstruction({programId, keys, data}),

--- a/packages/web3.js/test/kit-adapter-tests/instruction.test.ts
+++ b/packages/web3.js/test/kit-adapter-tests/instruction.test.ts
@@ -1,4 +1,11 @@
-import {AccountRole, address, blockhash, createNoopSigner} from '@solana/kit';
+import {
+  AccountRole,
+  address,
+  blockhash,
+  createNoopSigner,
+  parallelInstructionPlan,
+  singleInstructionPlan,
+} from '@solana/kit';
 import {getTransferSolInstruction} from '@solana-program/system';
 import {expect} from 'chai';
 
@@ -521,6 +528,22 @@ describe('ambiguous dual-shaped instructions', () => {
         dualInstruction() as unknown as TransactionInstruction,
       ),
     ).to.throw(/Ambiguous instruction/);
+  });
+
+  it('Transaction.add() rejects a dual-shaped leaf inside a parallel InstructionPlan', () => {
+    const sibling = {
+      programAddress: SystemProgram.programId.toBase58(),
+      accounts: [
+        {address: payer.toBase58(), role: AccountRole.WRITABLE_SIGNER},
+        {address: safeDestination.toBase58(), role: AccountRole.WRITABLE},
+      ],
+      data: new Uint8Array(),
+    };
+    const plan = parallelInstructionPlan([
+      singleInstructionPlan(dualInstruction() as never),
+      singleInstructionPlan(sibling as never),
+    ]);
+    expect(() => new Transaction().add(plan)).to.throw(/Ambiguous instruction/);
   });
 
   it('TransactionMessage rejects an object carrying both Kit and legacy fields', () => {


### PR DESCRIPTION
Reject if malformed instruction contains legacy and kit fields. 

Closes APE-252
Closes APE-253
