### PR TITLE
chore(wallet-adapter): add assertion for endpoint and chain

### DIFF
--- a/packages/wallet-adapter/src/__tests__/web3js-test.tsx
+++ b/packages/wallet-adapter/src/__tests__/web3js-test.tsx
@@ -401,7 +401,7 @@ it.each([
 it.each([
   ['https://api.mainnet-beta.solana.com', true],
   ['https://mainnet.helius-rpc.com/?api-key=x', true],
-  ['http://127.0.0.1:8899', true],
+  ['http://127.0.0.1:8899', false],
   ['https://api.devnet.solana.com', false],
   ['https://rpc.my-devnet-proxy.example', false],
   ['https://rpc.example.com', false],

--- a/packages/wallet-adapter/src/__tests__/web3js-test.tsx
+++ b/packages/wallet-adapter/src/__tests__/web3js-test.tsx
@@ -397,3 +397,30 @@ it.each([
     ).rejects.toMatchObject({name: causeName});
   },
 );
+
+it.each([
+  ['https://api.mainnet-beta.solana.com', true],
+  ['https://mainnet.helius-rpc.com/?api-key=x', true],
+  ['http://127.0.0.1:8899', true],
+  ['https://api.devnet.solana.com', false],
+  ['https://rpc.my-devnet-proxy.example', false],
+  ['https://rpc.example.com', false],
+] as const)(
+  'refuses to submit through %s when the endpoint names a different cluster (%s)',
+  async (rpcEndpoint, rejects) => {
+    const {owner, transaction} = await signingWallet();
+    const sendRawTransaction = vi.fn(async () => 'sig');
+    const connection = {
+      rpcEndpoint,
+      sendRawTransaction,
+    } as unknown as Connection;
+    const promise = owner.sendTransaction(transaction, connection);
+    if (rejects) {
+      await expect(promise).rejects.toMatchObject({name: 'WalletConfigError'});
+      expect(sendRawTransaction).not.toHaveBeenCalled();
+    } else {
+      await promise;
+      expect(sendRawTransaction).toHaveBeenCalledOnce();
+    }
+  },
+);

--- a/packages/wallet-adapter/src/wallet-controller.ts
+++ b/packages/wallet-adapter/src/wallet-controller.ts
@@ -27,6 +27,7 @@ import {
   signTransactionsWithKit,
 } from './transactions.js';
 import {
+  WalletConfigError,
   WalletError,
   WalletConnectionError,
   WalletDisconnectionError,
@@ -50,6 +51,45 @@ import {
   type WalletContextState,
   type WalletOperations,
 } from './types.js';
+
+/** A cluster the RPC endpoint URL unambiguously names, or `undefined` for custom hosts. */
+function chainForEndpoint(
+  endpoint: string,
+): WalletPluginConfig['chain'] | undefined {
+  let host: string;
+  try {
+    host = new URL(endpoint).hostname;
+  } catch {
+    return undefined;
+  }
+  if (host === 'localhost' || host === '127.0.0.1' || host === '[::1]')
+    return 'solana:localnet';
+  if (host === 'api.devnet.solana.com' || /(^|[.-])devnet([.-]|$)/.test(host))
+    return 'solana:devnet';
+  if (host === 'api.testnet.solana.com' || /(^|[.-])testnet([.-]|$)/.test(host))
+    return 'solana:testnet';
+  if (
+    host === 'api.mainnet-beta.solana.com' ||
+    /(^|[.-])mainnet([.-]|$)/.test(host)
+  )
+    return 'solana:mainnet';
+  return undefined;
+}
+
+/** Refuse to submit through an endpoint that plainly names a different cluster than the wallet chain. */
+function assertEndpointMatchesChain(
+  connection: Connection,
+  chain: WalletPluginConfig['chain'],
+) {
+  const endpoint = connection?.rpcEndpoint;
+  if (typeof endpoint !== 'string') return;
+  const inferred = chainForEndpoint(endpoint);
+  if (inferred !== undefined && inferred !== chain) {
+    throw new WalletConfigError(
+      `The connection endpoint ${endpoint} targets ${inferred} but the wallet is configured for ${chain}.`,
+    );
+  }
+}
 
 export interface WalletController
   extends Pick<
@@ -343,6 +383,7 @@ export function createWalletController({
     try {
       if (!connected)
         throw new WalletNotConnectedError('Wallet not connected.');
+      assertEndpointMatchesChain(connection, config.chain);
       const signer = connected.signer;
       if (!signer)
         throw new WalletNotReadyError(

--- a/packages/wallet-adapter/src/wallet-controller.ts
+++ b/packages/wallet-adapter/src/wallet-controller.ts
@@ -52,7 +52,9 @@ import {
   type WalletOperations,
 } from './types.js';
 
-/** A cluster the RPC endpoint URL unambiguously names, or `undefined` for custom hosts. */
+const CLUSTERS = ['devnet', 'testnet', 'mainnet'] as const;
+
+/** A cluster the RPC endpoint URL unambiguously names, or `undefined` for custom & local hosts. */
 function chainForEndpoint(
   endpoint: string,
 ): WalletPluginConfig['chain'] | undefined {
@@ -62,18 +64,10 @@ function chainForEndpoint(
   } catch {
     return undefined;
   }
-  if (host === 'localhost' || host === '127.0.0.1' || host === '[::1]')
-    return 'solana:localnet';
-  if (host === 'api.devnet.solana.com' || /(^|[.-])devnet([.-]|$)/.test(host))
-    return 'solana:devnet';
-  if (host === 'api.testnet.solana.com' || /(^|[.-])testnet([.-]|$)/.test(host))
-    return 'solana:testnet';
-  if (
-    host === 'api.mainnet-beta.solana.com' ||
-    /(^|[.-])mainnet([.-]|$)/.test(host)
-  )
-    return 'solana:mainnet';
-  return undefined;
+  const named = CLUSTERS.find(cluster =>
+    new RegExp(`(^|[.-])${cluster}([.-]|$)`).test(host),
+  );
+  return named && `solana:${named}`;
 }
 
 /** Refuse to submit through an endpoint that plainly names a different cluster than the wallet chain. */


### PR DESCRIPTION
Ensures endpoint and chain identifier do not blatantly mismatch to avoid confusion of sending to wrong cluster.
Edit: update to only check against public endpoints. We can make this more restrictive in the future if requested.

Closes APE-261