### PR TITLE
fix(wallet-adapter): skip redundant wallet reconnects

### DIFF
--- a/packages/wallet-adapter/src/__tests__/connection-test.tsx
+++ b/packages/wallet-adapter/src/__tests__/connection-test.tsx
@@ -114,6 +114,15 @@ it('reports a wallet that connects without accounts as not connected, as v1 apps
   await expect(owner.connect()).rejects.toBeInstanceOf(WalletNotConnectedError);
 });
 
+it('does not reconnect an already-connected wallet, as in v1', async () => {
+  const {a, owner} = await setup();
+  expect(a.wallet.features['standard:connect'].connect).toHaveBeenCalledOnce();
+
+  await owner.connect();
+
+  expect(a.wallet.features['standard:connect'].connect).toHaveBeenCalledOnce();
+});
+
 it('accepts any selection, as in v1, rejects connecting to one that does not resolve, and lists a duplicated name once', async () => {
   const {a, b, owner} = await setup();
   owner.select('Missing');

--- a/packages/wallet-adapter/src/wallet-controller.ts
+++ b/packages/wallet-adapter/src/wallet-controller.ts
@@ -198,6 +198,7 @@ export function createWalletController({
         if (active()) return;
       }
       target = selectedWallet();
+      if (active()?.wallet.name === target.name) return;
       await namespace.connect(target);
     } catch (error) {
       if (superseded(error)) throw error;


### PR DESCRIPTION
- Return early from `connect()` when the selected wallet is already active.
- Restore v1 behavior, where connecting an already-connected adapter was a no-op.
- Add regression coverage ensuring redundant connects do not invoke the wallet again. 

Closes APE-262, APE-263