### PR TITLE
fix(wallet-adapter): preserve concurrent transaction lifetime

### DIFF
--- a/packages/wallet-adapter/src/__tests__/web3js-test.tsx
+++ b/packages/wallet-adapter/src/__tests__/web3js-test.tsx
@@ -380,6 +380,44 @@ it.each(['draft', 'nonce'] as const)(
   },
 );
 
+it('does not overwrite a lifetime completed while fetching a blockhash', async () => {
+  const {owner, transaction, signTransaction} = await signingWallet();
+  const callerBlockhash = getBase58Decoder().decode(
+    new Uint8Array(32).fill(2),
+  ) as Blockhash;
+  const fetchedBlockhash = getBase58Decoder().decode(
+    new Uint8Array(32).fill(3),
+  ) as Blockhash;
+  transaction.recentBlockhash = undefined;
+  let resolveLookup!: (value: {
+    blockhash: Blockhash;
+    lastValidBlockHeight: bigint;
+  }) => void;
+  const getLatestBlockhash = vi.fn(
+    () =>
+      new Promise<{
+        blockhash: Blockhash;
+        lastValidBlockHeight: bigint;
+      }>(resolve => {
+        resolveLookup = resolve;
+      }),
+  );
+  const send = owner.sendTransaction(transaction, {
+    getLatestBlockhash,
+    sendRawTransaction: vi.fn(),
+  } as unknown as Connection);
+  transaction.recentBlockhash = callerBlockhash;
+  transaction.lastValidBlockHeight = 42n;
+  resolveLookup({blockhash: fetchedBlockhash, lastValidBlockHeight: 99n});
+  await send;
+  expect(transaction.recentBlockhash).toBe(callerBlockhash);
+  expect(transaction.lastValidBlockHeight).toBe(42n);
+  expect(
+    Transaction.from(signTransaction.mock.calls[0]![0]!.transaction)
+      .recentBlockhash,
+  ).toBe(callerBlockhash);
+});
+
 it.each([
   ['disconnected', 'WalletNotConnectedError'],
   ['read-only', 'WalletNotReadyError'],

--- a/packages/wallet-adapter/src/wallet-controller.ts
+++ b/packages/wallet-adapter/src/wallet-controller.ts
@@ -364,8 +364,11 @@ export function createWalletController({
               commitment: sendOptions.preflightCommitment,
               minContextSlot: sendOptions.minContextSlot,
             });
-          transaction.recentBlockhash = blockhash;
-          transaction.lastValidBlockHeight = lastValidBlockHeight;
+          // The caller can finish the lifetime while the RPC request is pending.
+          if (!transaction.recentBlockhash && !transaction.nonceInfo) {
+            transaction.recentBlockhash = blockhash;
+            transaction.lastValidBlockHeight = lastValidBlockHeight;
+          }
         }
       }
       if (signers?.length) {


### PR DESCRIPTION
avoid overwriting a legacy transaction lifetime if the caller completes it
while `sendTransaction` is awaiting `getLatestBlockhash`.

Add regression coverage for a caller-provided blockhash and block height.

Refs: SOLA8-2
Closes: APE-264