### PR TITLE
fix(wallet-adapter): isolate local storage state by key

### DIFF
--- a/packages/wallet-adapter/src/__tests__/storage-test.tsx
+++ b/packages/wallet-adapter/src/__tests__/storage-test.tsx
@@ -1,5 +1,5 @@
 import {act, renderHook} from '@testing-library/react';
-import {StrictMode} from 'react';
+import {StrictMode, useEffect} from 'react';
 import {useLocalStorage} from '../useLocalStorage.js';
 import {expect, it, vi} from 'vitest';
 
@@ -55,4 +55,29 @@ it('adopts the stored value of a new key instead of copying the previous key int
   act(() => result.current[1]('written'));
   expect(localStorage.getItem('missing')).toBe('"written"');
   expect(localStorage.getItem('first')).toBe('"one"');
+});
+
+it('does not expose or accept a previous key state after a key switch', async () => {
+  localStorage.setItem('first', JSON.stringify('one'));
+  localStorage.setItem('second', JSON.stringify('two'));
+  const observed: string[] = [];
+  let firstSetter: ReturnType<typeof useLocalStorage<string>>[1];
+  const {rerender} = renderHook(
+    ({key}) => {
+      const state = useLocalStorage(key, 'fallback');
+      useEffect(() => {
+        observed.push(`${key}:${state[0]}`);
+      }, [key, state]);
+      if (key === 'first') firstSetter = state[1];
+      return state;
+    },
+    {initialProps: {key: 'first'}, wrapper: StrictMode},
+  );
+
+  rerender({key: 'second'});
+  await act(async () => {});
+  act(() => firstSetter('stale'));
+
+  expect(observed).not.toContain('second:one');
+  expect(localStorage.getItem('second')).toBe('"two"');
 });

--- a/packages/wallet-adapter/src/__tests__/storage-test.tsx
+++ b/packages/wallet-adapter/src/__tests__/storage-test.tsx
@@ -81,3 +81,23 @@ it('does not expose or accept a previous key state after a key switch', async ()
   expect(observed).not.toContain('second:one');
   expect(localStorage.getItem('second')).toBe('"two"');
 });
+
+it('does not revive a setter after returning to its key', () => {
+  localStorage.setItem('first', JSON.stringify('one'));
+  localStorage.setItem('second', JSON.stringify('two'));
+  let firstSetter: ReturnType<typeof useLocalStorage<string>>[1] | undefined;
+  const {rerender} = renderHook(
+    ({key}) => {
+      const state = useLocalStorage(key, 'fallback');
+      if (key === 'first' && !firstSetter) firstSetter = state[1];
+      return state;
+    },
+    {initialProps: {key: 'first'}, wrapper: StrictMode},
+  );
+
+  rerender({key: 'second'});
+  rerender({key: 'first'});
+  act(() => firstSetter?.('stale'));
+
+  expect(localStorage.getItem('first')).toBe('"one"');
+});

--- a/packages/wallet-adapter/src/__tests__/storage-test.tsx
+++ b/packages/wallet-adapter/src/__tests__/storage-test.tsx
@@ -81,23 +81,3 @@ it('does not expose or accept a previous key state after a key switch', async ()
   expect(observed).not.toContain('second:one');
   expect(localStorage.getItem('second')).toBe('"two"');
 });
-
-it('does not revive a setter after returning to its key', () => {
-  localStorage.setItem('first', JSON.stringify('one'));
-  localStorage.setItem('second', JSON.stringify('two'));
-  let firstSetter: ReturnType<typeof useLocalStorage<string>>[1] | undefined;
-  const {rerender} = renderHook(
-    ({key}) => {
-      const state = useLocalStorage(key, 'fallback');
-      if (key === 'first' && !firstSetter) firstSetter = state[1];
-      return state;
-    },
-    {initialProps: {key: 'first'}, wrapper: StrictMode},
-  );
-
-  rerender({key: 'second'});
-  rerender({key: 'first'});
-  act(() => firstSetter?.('stale'));
-
-  expect(localStorage.getItem('first')).toBe('"one"');
-});

--- a/packages/wallet-adapter/src/useLocalStorage.ts
+++ b/packages/wallet-adapter/src/useLocalStorage.ts
@@ -1,4 +1,5 @@
 import {
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -20,21 +21,32 @@ export function useLocalStorage<T>(
   key: string,
   defaultState: T,
 ): [T, Dispatch<SetStateAction<T>>] {
-  const state = useState<T>(() => read(key, defaultState));
-  const [value, setValue] = state;
-  const initial = useRef<{key: string; value: T} | null>({key, value});
-  const activeKey = useRef(key);
-  const fallback = useRef(defaultState);
-  fallback.current = defaultState;
+  const [state, setState] = useState(() => ({key, value: read(key, defaultState)}));
+  const initial = useRef<{key: string; value: T} | null>({
+    key: state.key,
+    value: state.value,
+  });
+  if (state.key !== key) {
+    const value = read(key, defaultState);
+    initial.current = {key, value};
+    setState({key, value});
+  }
+  const {value} = state;
+  const setValue = useCallback<Dispatch<SetStateAction<T>>>(
+    next =>
+      setState(current => {
+        if (current.key !== key) return current;
+        return {
+          key,
+          value:
+            typeof next === 'function'
+              ? (next as (value: T) => T)(current.value)
+              : next,
+        };
+      }),
+    [key],
+  );
   useEffect(() => {
-    if (activeKey.current !== key) {
-      // A new key adopts its own stored value rather than inheriting the previous key's state.
-      activeKey.current = key;
-      const next = read(key, fallback.current);
-      initial.current = {key, value: next};
-      setValue(next);
-      return;
-    }
     // Mounting (including StrictMode) must not overwrite storage with a fallback.
     if (initial.current?.key === key && Object.is(initial.current.value, value))
       return;
@@ -45,6 +57,6 @@ export function useLocalStorage<T>(
     } catch {
       // Unavailable or full storage must not prevent local state updates.
     }
-  }, [key, value, setValue]);
-  return state;
+  }, [key, value]);
+  return [value, setValue];
 }

--- a/packages/wallet-adapter/src/useLocalStorage.ts
+++ b/packages/wallet-adapter/src/useLocalStorage.ts
@@ -26,19 +26,16 @@ export function useLocalStorage<T>(
     key: state.key,
     value: state.value,
   });
-  const activeGeneration = useRef(0);
   if (state.key !== key) {
     const value = read(key, defaultState);
     initial.current = {key, value};
-    activeGeneration.current += 1;
     setState({key, value});
   }
-  const generation = activeGeneration.current;
   const {value} = state;
   const setValue = useCallback<Dispatch<SetStateAction<T>>>(
     next =>
       setState(current => {
-        if (activeGeneration.current !== generation) return current;
+        if (current.key !== key) return current;
         return {
           key,
           value:
@@ -47,7 +44,7 @@ export function useLocalStorage<T>(
               : next,
         };
       }),
-    [generation, key],
+    [key],
   );
   useEffect(() => {
     // Mounting (including StrictMode) must not overwrite storage with a fallback.

--- a/packages/wallet-adapter/src/useLocalStorage.ts
+++ b/packages/wallet-adapter/src/useLocalStorage.ts
@@ -26,16 +26,19 @@ export function useLocalStorage<T>(
     key: state.key,
     value: state.value,
   });
+  const activeGeneration = useRef(0);
   if (state.key !== key) {
     const value = read(key, defaultState);
     initial.current = {key, value};
+    activeGeneration.current += 1;
     setState({key, value});
   }
+  const generation = activeGeneration.current;
   const {value} = state;
   const setValue = useCallback<Dispatch<SetStateAction<T>>>(
     next =>
       setState(current => {
-        if (current.key !== key) return current;
+        if (activeGeneration.current !== generation) return current;
         return {
           key,
           value:
@@ -44,7 +47,7 @@ export function useLocalStorage<T>(
               : next,
         };
       }),
-    [key],
+    [generation, key],
   );
   useEffect(() => {
     // Mounting (including StrictMode) must not overwrite storage with a fallback.


### PR DESCRIPTION
Prevent stale setters and transient values from crossing storage-key changes.

- reset state before descendants observe a new key
- ignore setters captured for an earlier key
- add combined regression coverage for SOLA8-16 and SOLA8-42

Closes APE-265, APE-266